### PR TITLE
Improve tolerance of classification-related issues that can suspend analysis

### DIFF
--- a/assemblyline-server/src/dispatcher/mod.rs
+++ b/assemblyline-server/src/dispatcher/mod.rs
@@ -70,7 +70,6 @@ const TASK_ASSIGNMENT_PATTERN: &str = "dispatcher-tasks-assigned-to-*";
 const DISPATCH_START_EVENTS: &str = "dispatcher-start-events-";
 const DISPATCH_RESULT_QUEUE: &str = "dispatcher-results-";
 const DISPATCH_COMMAND_QUEUE: &str = "dispatcher-commands-";
-const DISPATCH_DIRECTORY: &str = "dispatchers-directory";
 const DISPATCH_DIRECTORY_FINALIZE: &str = "dispatchers-directory-finalizing";
 const BAD_SID_HASH: &str = "bad-sid-hash";
 const QUEUE_EXPIRY: Duration = Duration::from_secs(60 * 60);
@@ -2728,7 +2727,15 @@ impl UserCache {
             }
         }
 
-        if let Some((user, _)) = self.datastore.user.get_if_exists(name, None).await.context("fetching user data...")? {
+        let user = match self.datastore.user.get_if_exists(name, None).await {
+            Ok(user) => user,
+            Err(err) => {
+                error!("Failed to fetch user {name}: {err:?}");
+                None
+            },
+        };
+
+        if let Some((user, _)) = user {
             let user = Arc::new(user);
             self.cache.lock().insert(name.to_string(), (user.clone(), Instant::now()));
             return Ok(Some(user))

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -13,7 +13,7 @@
 // remove after development, allow now so more important warnings can be seen
 // #![allow(dead_code)]
 
-use std::{path::PathBuf, process::ExitCode, sync::Arc};
+use std::{path::PathBuf, process::ExitCode, sync::Arc, fs};
 
 use anyhow::{Context, Result};
 use assemblyline_markings::classification::ClassificationParser;
@@ -95,6 +95,12 @@ enum Commands {
         /// If set and no tls configuration is provided revert to http rather than using a self signed certificate
         #[arg(long, default_value_t=false)]
         allow_http_mode: bool
+    },
+    ClassificationValidate {
+        // This command should accept a classification string that the parser will attempt to load and validate relative to the current definition
+        #[arg(last = true)]
+        classification: String,
+
     }
 }
 
@@ -105,6 +111,7 @@ impl Commands {
             Commands::Dispatcher { .. } => "dispatcher",
             Commands::Plumber { .. } => "plumber",
             Commands::ServiceAPI { .. } => "service_server",
+            Commands::ClassificationValidate { .. } => "classification_validate",
         }
     }
 }
@@ -122,6 +129,41 @@ async fn main() -> ExitCode {
     // and needs to be held until the program ends
     let _log_manager = configure_logging(&config).expect("Could not configure logging");
     info!("Configuration loaded from: {}", config_path.to_string_lossy());
+
+    // This utility command runs before initializing the core
+    if let Commands::ClassificationValidate { classification } = args.command {
+        // For troubleshooting ensure it's understood what the parser is using when performing validation
+        let c12n_config = match &config.classification.path {
+            Some(config_path) => {
+                info!("Testing against mounted classification configuration: {config_path:?}");
+                ready_classification(Some(&fs::read_to_string(config_path).expect("Could not read classification config from file"))).expect("Could not load classification config from file")
+            },
+            None => {
+                info!("No mounted classification configuration found. Proceeding with default configuration...");
+                ClassificationConfig::default()
+            }
+        };
+
+        // Validate the classification string and print the normalized result or an error
+        match ClassificationParser::new(c12n_config) {
+            Ok(parser) => {
+                match parser.normalize_classification(&classification) {
+                            Ok(norm_c12n) => {
+                                println!("Classification is valid: {norm_c12n:#?}");
+                                return ExitCode::SUCCESS;
+                            },
+                            Err(err) => {
+                                println!("Classification is invalid: {err:?}");
+                                return ExitCode::FAILURE;
+                            }
+                        }
+            },
+            Err(err) => {
+                println!("Classification configuration is invalid: {err:?}");
+                return ExitCode::FAILURE;
+            }
+        };        
+    }
 
     // Configure APM
     if let Some(url) = &config.core.metrics.apm_server.server_url {
@@ -162,6 +204,10 @@ async fn main() -> ExitCode {
         }
         Commands::ServiceAPI { allow_http_mode } => {
             crate::service_api::main(core, allow_http_mode).await
+        }
+        _ => {
+            error!("Module not implemented");
+            return ExitCode::FAILURE;
         }
     };
 

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -128,7 +128,20 @@ async fn main() -> ExitCode {
 
     // This utility command runs before initializing the core
     if let Commands::ValidateClassification { classification } = args.command {
-        return crate::validate_classification::main(classification, config.clone());       
+
+        // For troubleshooting ensure it's understood what the parser is using when performing validation
+        let c12n_config = match &config.classification.path {
+            Some(config_path) => {
+                println!("Testing against mounted classification configuration: {config_path:?}");
+                ready_classification(Some(&fs::read_to_string(config_path).expect("Could not read classification config from file"))).expect("Could not load classification config from file")
+            },
+            None => {
+                println!("No mounted classification configuration found. Proceeding with default configuration...");
+                ClassificationConfig::default()
+            }
+        };        
+
+        return crate::validate_classification::main(classification, c12n_config);       
     }
 
     // configure logging, the object returned here owns the log processing internals

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -55,6 +55,7 @@ mod string_utils;
 mod plumber;
 mod service_api;
 mod common;
+mod validate_classification;
 
 #[cfg(test)]
 mod tests;
@@ -96,7 +97,7 @@ enum Commands {
         #[arg(long, default_value_t=false)]
         allow_http_mode: bool
     },
-    ClassificationValidate {
+    ValidateClassification {
         // This command should accept a classification string that the parser will attempt to load and validate relative to the current definition
         #[arg(last = true)]
         classification: String,
@@ -111,7 +112,7 @@ impl Commands {
             Commands::Dispatcher { .. } => "dispatcher",
             Commands::Plumber { .. } => "plumber",
             Commands::ServiceAPI { .. } => "service_server",
-            Commands::ClassificationValidate { .. } => "classification_validate",
+            Commands::ValidateClassification { .. } => "validate_classification",
         }
     }
 }
@@ -127,42 +128,12 @@ async fn main() -> ExitCode {
 
     // configure logging, the object returned here owns the log processing internals
     // and needs to be held until the program ends
-    let _log_manager = configure_logging(&config).expect("Could not configure logging");
+    let _log_manager: flexi_logger::LoggerHandle = configure_logging(&config).expect("Could not configure logging");
     info!("Configuration loaded from: {}", config_path.to_string_lossy());
 
     // This utility command runs before initializing the core
-    if let Commands::ClassificationValidate { classification } = args.command {
-        // For troubleshooting ensure it's understood what the parser is using when performing validation
-        let c12n_config = match &config.classification.path {
-            Some(config_path) => {
-                info!("Testing against mounted classification configuration: {config_path:?}");
-                ready_classification(Some(&fs::read_to_string(config_path).expect("Could not read classification config from file"))).expect("Could not load classification config from file")
-            },
-            None => {
-                info!("No mounted classification configuration found. Proceeding with default configuration...");
-                ClassificationConfig::default()
-            }
-        };
-
-        // Validate the classification string and print the normalized result or an error
-        match ClassificationParser::new(c12n_config) {
-            Ok(parser) => {
-                match parser.normalize_classification(&classification) {
-                            Ok(norm_c12n) => {
-                                println!("Classification is valid: {norm_c12n:#?}");
-                                return ExitCode::SUCCESS;
-                            },
-                            Err(err) => {
-                                println!("Classification is invalid: {err:?}");
-                                return ExitCode::FAILURE;
-                            }
-                        }
-            },
-            Err(err) => {
-                println!("Classification configuration is invalid: {err:?}");
-                return ExitCode::FAILURE;
-            }
-        };        
+    if let Commands::ValidateClassification { classification } = args.command {
+        return crate::validate_classification::main(classification, config.clone());       
     }
 
     // Configure APM

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -126,15 +126,15 @@ async fn main() -> ExitCode {
     // Load configuration
     let (config, config_path) = load_configuration(args.config).await.expect("Could not load configuration");
 
-    // configure logging, the object returned here owns the log processing internals
-    // and needs to be held until the program ends
-    let _log_manager: flexi_logger::LoggerHandle = configure_logging(&config).expect("Could not configure logging");
-    info!("Configuration loaded from: {}", config_path.to_string_lossy());
-
     // This utility command runs before initializing the core
     if let Commands::ValidateClassification { classification } = args.command {
         return crate::validate_classification::main(classification, config.clone());       
     }
+
+    // configure logging, the object returned here owns the log processing internals
+    // and needs to be held until the program ends
+    let _log_manager: flexi_logger::LoggerHandle = configure_logging(&config).expect("Could not configure logging");
+    info!("Configuration loaded from: {}", config_path.to_string_lossy());
 
     // Configure APM
     if let Some(url) = &config.core.metrics.apm_server.server_url {

--- a/assemblyline-server/src/validate_classification/mod.rs
+++ b/assemblyline-server/src/validate_classification/mod.rs
@@ -1,5 +1,4 @@
 // Used for validating a classification string against the current configuration from the command-line
-use log::{info};
 use std::{fs};
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -13,11 +12,11 @@ pub fn main(classification: String, config: Arc<Config>) -> std::process::ExitCo
     // For troubleshooting ensure it's understood what the parser is using when performing validation
     let c12n_config = match &config.classification.path {
         Some(config_path) => {
-            info!("Testing against mounted classification configuration: {config_path:?}");
+            println!("Testing against mounted classification configuration: {config_path:?}");
             ready_classification(Some(&fs::read_to_string(config_path).expect("Could not read classification config from file"))).expect("Could not load classification config from file")
         },
         None => {
-            info!("No mounted classification configuration found. Proceeding with default configuration...");
+            println!("No mounted classification configuration found. Proceeding with default configuration...");
             ClassificationConfig::default()
         }
     };
@@ -27,17 +26,17 @@ pub fn main(classification: String, config: Arc<Config>) -> std::process::ExitCo
         Ok(parser) => {
             match parser.normalize_classification(&classification) {
                         Ok(norm_c12n) => {
-                            info!("Classification is valid: {norm_c12n:#?}");
+                            println!("Classification is valid: {norm_c12n:#?}");
                             return ExitCode::SUCCESS;
                         },
                         Err(err) => {
-                            info!("Classification is invalid: {err:?}");
+                            println!("Classification is invalid: {err:?}");
                             return ExitCode::FAILURE;
                         }
                     }
         },
         Err(err) => {
-            info!("Classification configuration is invalid: {err:?}");
+            println!("Classification configuration is invalid: {err:?}");
             return ExitCode::FAILURE;
         }
     };  

--- a/assemblyline-server/src/validate_classification/mod.rs
+++ b/assemblyline-server/src/validate_classification/mod.rs
@@ -1,26 +1,10 @@
 // Used for validating a classification string against the current configuration from the command-line
-use std::{fs};
 use std::process::ExitCode;
-use std::sync::Arc;
 
 use assemblyline_markings::classification::ClassificationParser;
-use assemblyline_markings::config::{ClassificationConfig, ready_classification};
-use assemblyline_models::config::Config;
+use assemblyline_markings::config::ClassificationConfig;
 
-pub fn main(classification: String, config: Arc<Config>) -> std::process::ExitCode {
-
-    // For troubleshooting ensure it's understood what the parser is using when performing validation
-    let c12n_config = match &config.classification.path {
-        Some(config_path) => {
-            println!("Testing against mounted classification configuration: {config_path:?}");
-            ready_classification(Some(&fs::read_to_string(config_path).expect("Could not read classification config from file"))).expect("Could not load classification config from file")
-        },
-        None => {
-            println!("No mounted classification configuration found. Proceeding with default configuration...");
-            ClassificationConfig::default()
-        }
-    };
-
+pub fn main(classification: String, c12n_config: ClassificationConfig) -> std::process::ExitCode {
     // Validate the classification string and print the normalized result or an error
     match ClassificationParser::new(c12n_config) {
         Ok(parser) => {
@@ -45,27 +29,32 @@ pub fn main(classification: String, config: Arc<Config>) -> std::process::ExitCo
 #[cfg(test)]
 mod tests {
     use super::main;
-    use crate::load_configuration;
+    use assemblyline_markings::config::{ClassificationConfig, ready_classification};
+
+    async fn setup() -> ClassificationConfig {
+        // Create a default classification configuration for testing
+        let mut c12n_config = ready_classification(None).unwrap();
+
+        // Enable enforcement of classification rules for testing purposes
+        c12n_config.enforce = true;
+        c12n_config
+    }
 
     #[tokio::test]
     async fn test_valid_classification() {
-        // Load configuration
-        let (config, _) = load_configuration(None).await.expect("Could not load configuration");
-
         // A simple test to ensure the validation function works as expected with a valid classification string
+        let c12n_config = setup().await;
         let classification = "TLP:W//REL CSE".to_string();
-        let result = main(classification, config.clone());
+        let result = main(classification, c12n_config);
         assert_eq!(result, std::process::ExitCode::SUCCESS);
     }
 
     #[tokio::test]
     async fn test_invalid_classification() {
-        // Load configuration
-        let (config, _) = load_configuration(None).await.expect("Could not load configuration");
-
         // A simple test to ensure the validation function works as expected with an invalid classification string
         let invalid_classification = "TLP:R//REL CSE".to_string();
-        let result = main(invalid_classification, config.clone());
+        let c12n_config = setup().await;
+        let result = main(invalid_classification, c12n_config);
         assert_eq!(result, std::process::ExitCode::FAILURE);
     }
 }

--- a/assemblyline-server/src/validate_classification/mod.rs
+++ b/assemblyline-server/src/validate_classification/mod.rs
@@ -1,0 +1,72 @@
+// Used for validating a classification string against the current configuration from the command-line
+use log::{info};
+use std::{fs};
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use assemblyline_markings::classification::ClassificationParser;
+use assemblyline_markings::config::{ClassificationConfig, ready_classification};
+use assemblyline_models::config::Config;
+
+pub fn main(classification: String, config: Arc<Config>) -> std::process::ExitCode {
+
+    // For troubleshooting ensure it's understood what the parser is using when performing validation
+    let c12n_config = match &config.classification.path {
+        Some(config_path) => {
+            info!("Testing against mounted classification configuration: {config_path:?}");
+            ready_classification(Some(&fs::read_to_string(config_path).expect("Could not read classification config from file"))).expect("Could not load classification config from file")
+        },
+        None => {
+            info!("No mounted classification configuration found. Proceeding with default configuration...");
+            ClassificationConfig::default()
+        }
+    };
+
+    // Validate the classification string and print the normalized result or an error
+    match ClassificationParser::new(c12n_config) {
+        Ok(parser) => {
+            match parser.normalize_classification(&classification) {
+                        Ok(norm_c12n) => {
+                            info!("Classification is valid: {norm_c12n:#?}");
+                            return ExitCode::SUCCESS;
+                        },
+                        Err(err) => {
+                            info!("Classification is invalid: {err:?}");
+                            return ExitCode::FAILURE;
+                        }
+                    }
+        },
+        Err(err) => {
+            info!("Classification configuration is invalid: {err:?}");
+            return ExitCode::FAILURE;
+        }
+    };  
+}
+
+#[cfg(test)]
+mod tests {
+    use super::main;
+    use crate::load_configuration;
+
+    #[tokio::test]
+    async fn test_valid_classification() {
+        // Load configuration
+        let (config, _) = load_configuration(None).await.expect("Could not load configuration");
+
+        // A simple test to ensure the validation function works as expected with a valid classification string
+        let classification = "TLP:W//REL CSE".to_string();
+        let result = main(classification, config.clone());
+        assert_eq!(result, std::process::ExitCode::SUCCESS);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_classification() {
+        // Load configuration
+        let (config, _) = load_configuration(None).await.expect("Could not load configuration");
+
+        // A simple test to ensure the validation function works as expected with an invalid classification string
+        let invalid_classification = "TLP:R//REL CSE".to_string();
+        let result = main(invalid_classification, config.clone());
+        assert_eq!(result, std::process::ExitCode::FAILURE);
+    }
+}


### PR DESCRIPTION
Example of helper command usage:

```bash
# Valid marking
assemblyline-server classification-validate -- "TLP:W//REL CSE"
> Classification is valid: "TLP:CLEAR//REL TO CSE"

# Invalid marking
assemblyline-server classification-validate -- "TLP:R//REL CSE"
> Classification is invalid: InvalidClassification("Classification level 'TLP:R' was not found in your classification definition.")
```