### PR TITLE
feat: add readonly_storage support to FileStore

### DIFF
--- a/assemblyline-filestore/src/filestore.rs
+++ b/assemblyline-filestore/src/filestore.rs
@@ -183,6 +183,10 @@ impl FileStore {
     /// Read-only transports are skipped.
     pub async fn put(&self, name: &str, body: &Bytes) -> Result<()> {
         for transport in &self.transports {
+            if transport.read_only() {
+                // Skip on read-only transports
+                continue;
+            }
             transport.put(name, body).await?;
         }
         Ok(())
@@ -192,7 +196,7 @@ impl FileStore {
     /// Errors will be supressed as long as any transport contains the file.
     pub async fn exists(&self, name: &str) -> Result<bool> {
         let mut last_error = None;
-        for transport in self.transports.iter() {
+        for transport in &self.transports {
             match transport.exists(name).await {
                 Ok(true) => return Ok(true),
                 Ok(false) => continue,
@@ -212,7 +216,7 @@ impl FileStore {
     /// Returns errors only if all transports fail, otherwise errors will be logged as warnings.
     pub async fn get(&self, name: &str) -> Result<Option<Vec<u8>>> {
         let mut last_error = None;
-        for transport in self.transports.iter() {
+        for transport in &self.transports {
             match transport.get(name).await {
                 Ok(bytes) => {
                     return Ok(bytes)
@@ -234,7 +238,7 @@ impl FileStore {
     /// If the file does not exist it will be created. If it does exist it will be replaced.
     pub async fn download(&self, name: &str, path: &Path) -> Result<()> {
         let mut errors = vec![];
-        for transport in self.transports.iter() {
+        for transport in &self.transports {
             match transport.download(name, path).await {
                 Ok(()) => {
                     return Ok(())
@@ -286,7 +290,7 @@ impl FileStore {
     /// Returns the total expected length of the stream and a message receiver of data buffers.
     pub async fn stream(&self, name: &str) -> Result<(u64, tokio::sync::mpsc::Receiver<Result<Bytes, std::io::Error>>)> {
         let mut last_error = None;
-        for transport in self.transports.iter() {
+        for transport in &self.transports {
             match transport.stream(name).await {
                 Ok((size, stream)) => return Ok((size, stream)),
                 Err(err) => last_error = Some(err),

--- a/assemblyline-filestore/src/filestore.rs
+++ b/assemblyline-filestore/src/filestore.rs
@@ -20,8 +20,6 @@ use crate::transport::sftp::{SftpParameters, TransportSftp};
 pub struct FileStore {
     /// Transports that support both read and write operations
     transports: Vec<Box<dyn Transport>>,
-    /// Transports that only support read operations (e.g. legacy storage with unmigrated data)
-    readonly_transports: Vec<Box<dyn Transport>>,
 }
 
 
@@ -34,27 +32,7 @@ impl FileStore {
         }
         info!("FileStore initialized with {} writable transport(s)", transports.len());
         Ok(Arc::new(Self {
-            transports,
-            readonly_transports: vec![],
-        }))
-    }
-
-    /// Open writable and read-only urls with default parameters.
-    /// Write operations only target writable transports. Read operations search both pools.
-    pub async fn open_with_readonly(urls: &[String], readonly_urls: &[String]) -> Result<Arc<FileStore>> {
-        let mut transports = vec![];
-        for url in urls {
-            transports.push(Self::create_transport(url, None).await?)
-        }
-        let mut readonly_transports = vec![];
-        for url in readonly_urls {
-            readonly_transports.push(Self::create_transport(url, None).await?)
-        }
-        info!("FileStore initialized with {} writable transport(s) and {} readonly transport(s)",
-              transports.len(), readonly_transports.len());
-        Ok(Arc::new(Self {
-            transports,
-            readonly_transports,
+            transports
         }))
     }
 
@@ -62,7 +40,6 @@ impl FileStore {
     pub async fn with_limit_retries(url: &str) -> Result<Arc<FileStore>> {
         Ok(Arc::new(Self {
             transports: vec![Self::create_transport(url, Some(1)).await?],
-            readonly_transports: vec![],
         }))
     }
 
@@ -84,6 +61,14 @@ impl FileStore {
             percent_encoding::percent_decode_str(password).decode_utf8_lossy().to_string()
         });
 
+        let read_only = url.query_pairs().find_map(|(name, value)| {
+            if name == "read_only" {
+                Some(read_bool(&value))
+            } else {
+                None
+            }
+        }).unwrap_or(false);
+
         // user = parsed.username or ''
 
 
@@ -102,7 +87,7 @@ impl FileStore {
                 // t = TransportLocal(base=base, **extras)
 
                 let path = base.parse()?;
-                Ok(Box::new(LocalTransport::new(path)))
+                Ok(Box::new(LocalTransport::new(path, read_only)))
             }
             "azure" => {
                 use crate::transport::azure::{AzureParameters, TransportAzure};
@@ -127,7 +112,7 @@ impl FileStore {
                 };
                 let base = url.path().to_owned();
 
-                Ok(Box::new(TransportAzure::new(host, base, parameters, connection_attempts).await?))
+                Ok(Box::new(TransportAzure::new(host, base, parameters, connection_attempts, read_only).await?))
             },
             "s3" => {
                 use crate::transport::s3::{S3Parameters, TransportS3};
@@ -150,7 +135,7 @@ impl FileStore {
                     value => Some(value.to_owned())
                 };
 
-                Ok(Box::new(TransportS3::new(base, host.map(str::to_string), port, user, password, connection_attempts, parameters).await?))
+                Ok(Box::new(TransportS3::new(base, host.map(str::to_string), port, user, password, connection_attempts, parameters, read_only).await?))
             }
             "ftp" | "ftps" => {
                 let host = match host {
@@ -164,9 +149,9 @@ impl FileStore {
                 };
 
                 if url.scheme().eq_ignore_ascii_case("ftps") {
-                    Ok(Box::new(TransportFtp::new_secure(connection_attempts, &base, host, port.unwrap_or(21), user, password).await?))
+                    Ok(Box::new(TransportFtp::new_secure(connection_attempts, &base, host, port.unwrap_or(21), user, password, read_only).await?))
                 } else {
-                    Ok(Box::new(TransportFtp::new(connection_attempts, &base, host, port.unwrap_or(21), user, password).await?))
+                    Ok(Box::new(TransportFtp::new(connection_attempts, &base, host, port.unwrap_or(21), user, password, read_only).await?))
                 }
             }
             "sftp" => {
@@ -186,7 +171,7 @@ impl FileStore {
                     }
                 }
 
-                Ok(Box::new(TransportSftp::new(base, host, password, user, port.unwrap_or(22), connection_attempts, params).await?))
+                Ok(Box::new(TransportSftp::new(base, host, password, user, port.unwrap_or(22), connection_attempts, params, read_only).await?))
             }
             _ => {
                 bail!("Not an accepted filestore scheme: {}", url.scheme());
@@ -207,7 +192,7 @@ impl FileStore {
     /// Errors will be supressed as long as any transport contains the file.
     pub async fn exists(&self, name: &str) -> Result<bool> {
         let mut last_error = None;
-        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
+        for transport in self.transports.iter() {
             match transport.exists(name).await {
                 Ok(true) => return Ok(true),
                 Ok(false) => continue,
@@ -227,12 +212,9 @@ impl FileStore {
     /// Returns errors only if all transports fail, otherwise errors will be logged as warnings.
     pub async fn get(&self, name: &str) -> Result<Option<Vec<u8>>> {
         let mut last_error = None;
-        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
+        for transport in self.transports.iter() {
             match transport.get(name).await {
                 Ok(bytes) => {
-                    if self.readonly_transports.iter().any(|t| std::ptr::eq(t.as_ref(), transport.as_ref())) {
-                        debug!("File {name} found on readonly transport (not yet migrated to primary)");
-                    }
                     return Ok(bytes)
                 },
                 Err(err) => {
@@ -252,12 +234,9 @@ impl FileStore {
     /// If the file does not exist it will be created. If it does exist it will be replaced.
     pub async fn download(&self, name: &str, path: &Path) -> Result<()> {
         let mut errors = vec![];
-        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
+        for transport in self.transports.iter() {
             match transport.download(name, path).await {
                 Ok(()) => {
-                    if self.readonly_transports.iter().any(|t| std::ptr::eq(t.as_ref(), transport.as_ref())) {
-                        debug!("File {name} found on readonly transport (not yet migrated to primary)");
-                    }
                     return Ok(())
                 },
                 Err(err) => {
@@ -277,6 +256,11 @@ impl FileStore {
     pub async fn upload(&self, path: &Path, name: &str) -> Result<()> {
         let mut last_error = None;
         for transport in &self.transports {
+            if transport.read_only() {
+                // Skip on read-only transports
+                continue;
+            }
+
             if let Err(err) = transport.upload(path, name).await {
                 last_error = Some(err);
             }
@@ -302,7 +286,7 @@ impl FileStore {
     /// Returns the total expected length of the stream and a message receiver of data buffers.
     pub async fn stream(&self, name: &str) -> Result<(u64, tokio::sync::mpsc::Receiver<Result<Bytes, std::io::Error>>)> {
         let mut last_error = None;
-        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
+        for transport in self.transports.iter() {
             match transport.stream(name).await {
                 Ok((size, stream)) => return Ok((size, stream)),
                 Err(err) => last_error = Some(err),
@@ -318,6 +302,10 @@ impl FileStore {
     /// Read-only transports are skipped.
     pub async fn delete(&self, name: &str) -> Result<()> {
         for transport in &self.transports {
+            if transport.read_only() {
+                // Skip on read-only transports
+                continue;
+            }
             transport.delete(name).await?;
         }
         Ok(())

--- a/assemblyline-filestore/src/filestore.rs
+++ b/assemblyline-filestore/src/filestore.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use bytes::Bytes;
-use log::{debug, info, warn};
+use log::{info, warn};
 
 use crate::transport::Transport;
 use crate::transport::ftp::TransportFtp;

--- a/assemblyline-filestore/src/filestore.rs
+++ b/assemblyline-filestore/src/filestore.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
 use bytes::Bytes;
-use log::warn;
+use log::{debug, info, warn};
 
 use crate::transport::Transport;
 use crate::transport::ftp::TransportFtp;
@@ -11,9 +11,17 @@ use crate::transport::local::LocalTransport;
 use crate::transport::sftp::{SftpParameters, TransportSftp};
 
 /// An abstract interface over one or more storage transports.
+///
+/// Supports separate writable and read-only transport pools. Write operations
+/// (upload, put, delete) only target writable transports. Read operations
+/// (download, get, exists, stream) search both pools, with read-only transports
+/// used as a fallback for data that hasn't been migrated to the primary storage.
 #[derive(Debug)]
 pub struct FileStore {
+    /// Transports that support both read and write operations
     transports: Vec<Box<dyn Transport>>,
+    /// Transports that only support read operations (e.g. legacy storage with unmigrated data)
+    readonly_transports: Vec<Box<dyn Transport>>,
 }
 
 
@@ -24,15 +32,37 @@ impl FileStore {
         for url in urls {
             transports.push(Self::create_transport(url, None).await?)
         }
+        info!("FileStore initialized with {} writable transport(s)", transports.len());
         Ok(Arc::new(Self {
-            transports
+            transports,
+            readonly_transports: vec![],
+        }))
+    }
+
+    /// Open writable and read-only urls with default parameters.
+    /// Write operations only target writable transports. Read operations search both pools.
+    pub async fn open_with_readonly(urls: &[String], readonly_urls: &[String]) -> Result<Arc<FileStore>> {
+        let mut transports = vec![];
+        for url in urls {
+            transports.push(Self::create_transport(url, None).await?)
+        }
+        let mut readonly_transports = vec![];
+        for url in readonly_urls {
+            readonly_transports.push(Self::create_transport(url, None).await?)
+        }
+        info!("FileStore initialized with {} writable transport(s) and {} readonly transport(s)",
+              transports.len(), readonly_transports.len());
+        Ok(Arc::new(Self {
+            transports,
+            readonly_transports,
         }))
     }
 
     /// Open a single url with retrying disabled
     pub async fn with_limit_retries(url: &str) -> Result<Arc<FileStore>> {
         Ok(Arc::new(Self {
-            transports: vec![Self::create_transport(url, Some(1)).await?]
+            transports: vec![Self::create_transport(url, Some(1)).await?],
+            readonly_transports: vec![],
         }))
     }
 
@@ -164,7 +194,8 @@ impl FileStore {
         }
     }
 
-    /// Upload a buffer to all transports
+    /// Upload a buffer to all writable transports.
+    /// Read-only transports are skipped.
     pub async fn put(&self, name: &str, body: &Bytes) -> Result<()> {
         for transport in &self.transports {
             transport.put(name, body).await?;
@@ -172,11 +203,11 @@ impl FileStore {
         Ok(())
     }
 
-    /// Check if a given blob is defined in any transport.
+    /// Check if a given blob is defined in any transport (writable or read-only).
     /// Errors will be supressed as long as any transport contains the file.
     pub async fn exists(&self, name: &str) -> Result<bool> {
         let mut last_error = None;
-        for transport in &self.transports {
+        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
             match transport.exists(name).await {
                 Ok(true) => return Ok(true),
                 Ok(false) => continue,
@@ -192,13 +223,18 @@ impl FileStore {
         return Ok(false)
     }
 
-    /// Pull blob to in memory buffer.
+    /// Pull blob to in memory buffer from any transport (writable or read-only).
     /// Returns errors only if all transports fail, otherwise errors will be logged as warnings.
     pub async fn get(&self, name: &str) -> Result<Option<Vec<u8>>> {
         let mut last_error = None;
-        for transport in &self.transports {
+        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
             match transport.get(name).await {
-                Ok(bytes) => return Ok(bytes),
+                Ok(bytes) => {
+                    if self.readonly_transports.iter().any(|t| std::ptr::eq(t.as_ref(), transport.as_ref())) {
+                        debug!("File {name} found on readonly transport (not yet migrated to primary)");
+                    }
+                    return Ok(bytes)
+                },
                 Err(err) => {
                     warn!("error fetching blob [{name}] from transport {transport:?}: {err}");
                     last_error = Some(err);
@@ -212,13 +248,18 @@ impl FileStore {
         }
     }
 
-    /// Download a blob and write it to a local file.
+    /// Download a blob and write it to a local file from any transport (writable or read-only).
     /// If the file does not exist it will be created. If it does exist it will be replaced.
     pub async fn download(&self, name: &str, path: &Path) -> Result<()> {
         let mut errors = vec![];
-        for transport in &self.transports {
+        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
             match transport.download(name, path).await {
-                Ok(()) => return Ok(()),
+                Ok(()) => {
+                    if self.readonly_transports.iter().any(|t| std::ptr::eq(t.as_ref(), transport.as_ref())) {
+                        debug!("File {name} found on readonly transport (not yet migrated to primary)");
+                    }
+                    return Ok(())
+                },
                 Err(err) => {
                     errors.push(format!("Could not download file: [{name}] from {transport:?}: {err}"));
                     continue
@@ -231,7 +272,8 @@ impl FileStore {
         Err(anyhow::anyhow!(errors.join("\n")).context("All transports failed to fetch"))
     }
 
-    /// Upload a local file as a named blob.
+    /// Upload a local file as a named blob to writable transports only.
+    /// Read-only transports are skipped.
     pub async fn upload(&self, path: &Path, name: &str) -> Result<()> {
         let mut last_error = None;
         for transport in &self.transports {
@@ -245,7 +287,7 @@ impl FileStore {
         }
     }
 
-    /// Upload a collection of local files.
+    /// Upload a collection of local files to writable transports only.
     pub async fn upload_batch(&self, local_remote_tuples: &[(&Path, &str)]) -> Vec<(PathBuf, String, String)> {
         let mut failed_tuples = vec![];
         for (src_path, dst_path) in local_remote_tuples {
@@ -256,11 +298,11 @@ impl FileStore {
         return failed_tuples
     }
 
-    /// Stream the content of a blob.
+    /// Stream the content of a blob from any transport (writable or read-only).
     /// Returns the total expected length of the stream and a message receiver of data buffers.
     pub async fn stream(&self, name: &str) -> Result<(u64, tokio::sync::mpsc::Receiver<Result<Bytes, std::io::Error>>)> {
         let mut last_error = None;
-        for transport in &self.transports {
+        for transport in self.transports.iter().chain(self.readonly_transports.iter()) {
             match transport.stream(name).await {
                 Ok((size, stream)) => return Ok((size, stream)),
                 Err(err) => last_error = Some(err),
@@ -272,7 +314,8 @@ impl FileStore {
         }
     }
 
-    /// Remove a blob from the storage
+    /// Remove a blob from writable storage only.
+    /// Read-only transports are skipped.
     pub async fn delete(&self, name: &str) -> Result<()> {
         for transport in &self.transports {
             transport.delete(name).await?;

--- a/assemblyline-filestore/src/tests/mod.rs
+++ b/assemblyline-filestore/src/tests/mod.rs
@@ -284,7 +284,7 @@ async fn parallel_activity(fs: Arc<FileStore>) {
 
 // Test that a FileStore in read-only mode properly disallows writes and deletes but still allows reads.
 async fn read_only(url: String) {
-    use url::Url;    
+    use url::Url;
     // Initialize with a single file for testing existence and retrieval
     let fs = FileStore::with_limit_retries(&url).await.unwrap();
     assert!(fs.put("test", &Bytes::copy_from_slice(b"test")).await.is_ok());
@@ -297,7 +297,7 @@ async fn read_only(url: String) {
     assert!(fs.get("__missing_file__").await.unwrap().is_none());
     assert!(fs_ro.exists("test").await.unwrap());
     assert!(fs_ro.get("test").await.unwrap().is_some());
-    
+
 
     // Writes should fail but not error
     assert!(fs_ro.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
@@ -305,9 +305,5 @@ async fn read_only(url: String) {
 
     // Deletes should fail but not error
     assert!(fs_ro.delete("test").await.is_ok());
-    assert!(fs_ro.exists("test").await.unwrap());    
-
-
-    assert!(fs.get("__missing_file__").await.unwrap().is_none());
-    assert!(fs.exists("test").await.unwrap());
+    assert!(fs_ro.exists("test").await.unwrap());
 }

--- a/assemblyline-filestore/src/tests/mod.rs
+++ b/assemblyline-filestore/src/tests/mod.rs
@@ -26,44 +26,28 @@ fn init() {
 #[tokio::test]
 async fn test_azure() {
     init();
-    let fs = FileStore::with_limit_retries("azure://alpytest.blob.core.windows.net/pytest/").await.unwrap();
+    let url = "azure://alpytest.blob.core.windows.net/pytest/";
+    let fs = FileStore::with_limit_retries(url).await.unwrap();
     println!("{fs:?}");
 
     assert!(fs.get("__missing_file__").await.unwrap().is_none());
     assert!(fs.exists("test").await.unwrap());
     assert!(fs.get("test").await.unwrap().is_some());
     assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_err());
+    read_only(url.to_string()).await;
 }
 
 /// test Azure filestore against the local emulator container
 #[tokio::test(flavor = "multi_thread")]
 async fn test_azure_emulator() {
     init();
-    let fs = FileStore::with_limit_retries("azure://localhost/?emulator=true&allow_directory_access=true").await.unwrap();
+    let url = "azure://localhost/?emulator=true&allow_directory_access=true";
+    let fs = FileStore::with_limit_retries(url).await.unwrap();
     println!("{fs:?}");
 
     common_actions(fs.clone()).await;
     big_file(fs).await;
-}
-
-/// test Azure filestore in read-only mode
-#[tokio::test(flavor = "multi_thread")]
-async fn test_azure_readonly() {
-    init();
-    let fs = FileStore::with_limit_retries("azure://alpytest.blob.core.windows.net/pytest/?read_only=true").await.unwrap();
-    println!("{fs:?}");
-
-    assert!(fs.get("__missing_file__").await.unwrap().is_none());
-    assert!(fs.exists("test").await.unwrap());
-    assert!(fs.get("test").await.unwrap().is_some());
-
-    // Writes should fail but not error
-    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
-    assert!(!fs.exists("bob").await.unwrap());
-
-    // Deletes should fail but not error
-    assert!(fs.delete("test").await.is_ok());
-    assert!(fs.exists("test").await.unwrap());    
+    read_only(url.to_string()).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -73,27 +57,7 @@ async fn test_sftp() {
     let fs = FileStore::with_limit_retries(&server).await.unwrap();
     common_actions(fs).await;
     // big_file(fs).await; VERY SLOW
-}
-
-/// Test SFTP filestore in read-only mode
-#[tokio::test(flavor = "multi_thread")]
-async fn test_sftp_readonly() {
-    init();
-    let server = start_temp_sftp_server().await;
-    let fs = FileStore::with_limit_retries(&format!("sftp://{server}/?read_only=true")).await.unwrap();
-    
-    // Ensure that we can read files but not write or delete
-    assert!(fs.get("__missing_file__").await.unwrap().is_none());
-    assert!(fs.exists("test").await.unwrap());
-    assert!(fs.get("test").await.unwrap().is_some());
-
-    // Writes should fail but not error
-    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
-    assert!(!fs.exists("bob").await.unwrap());
-
-    // Deletes should fail but not error
-    assert!(fs.delete("test").await.is_ok());
-    assert!(fs.exists("test").await.unwrap());    
+    read_only(server).await;
 }
 
 /// Run some operations against an in-process ftp server
@@ -101,9 +65,11 @@ async fn test_sftp_readonly() {
 async fn ftp() {
     init();
     let temp_ftp_server = start_temp_ftp_server(None).await;
-    let fs = FileStore::with_limit_retries(&format!("ftp://{temp_ftp_server}")).await.unwrap();
+    let url = format!("ftp://{temp_ftp_server}");
+    let fs = FileStore::with_limit_retries(&url).await.unwrap();
     common_actions(fs.clone()).await;
     big_file(fs).await;
+    read_only(url).await;
 }
 
 /// Run some operations against an in-process ftp server
@@ -112,28 +78,11 @@ async fn ftps() {
     init();
     let certs = random_tls_certificate().unwrap();
     let temp_ftps_server = start_temp_ftp_server(Some(certs)).await;
-    let fs = FileStore::with_limit_retries(&format!("ftps://{temp_ftps_server}")).await.unwrap();
+    let url = format!("ftps://{temp_ftps_server}");
+    let fs = FileStore::with_limit_retries(&url).await.unwrap();
     common_actions(fs.clone()).await;
     big_file(fs).await;
-}
-
-// Test FTP filestore in read-only mode
-#[tokio::test(flavor = "multi_thread")]
-async fn test_ftp_readonly() {
-    init();
-    let temp_ftp_server = start_temp_ftp_server(None).await;
-    let fs = FileStore::with_limit_retries(&format!("ftp://{temp_ftp_server}/?read_only=true")).await.unwrap();
-    assert!(fs.get("__missing_file__").await.unwrap().is_none());
-    assert!(fs.exists("test").await.unwrap());
-    assert!(fs.get("test").await.unwrap().is_some());
-
-    // Writes should fail but not error
-    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
-    assert!(!fs.exists("bob").await.unwrap());
-
-    // Deletes should fail but not error
-    assert!(fs.delete("test").await.is_ok());
-    assert!(fs.exists("test").await.unwrap());    
+    read_only(url).await;
 }
 
 /// Run many parallel operations against an in-process ftp server
@@ -163,36 +112,15 @@ async fn test_file() {
     let fs = FileStore::with_limit_retries(&url).await.unwrap();
     common_actions(fs.clone()).await;
     big_file(fs).await;
-}
-
-/// Test local filesystem based filestore in read-only mode
-#[tokio::test(flavor = "multi_thread")]
-async fn test_file_readonly() {
-    let directory = tempfile::tempdir().unwrap();
-    let url = format!("file://{}?read_only=true", directory.path().to_string_lossy());
-    println!("{url}");
-    let fs = FileStore::with_limit_retries(&url).await.unwrap();
-    assert!(fs.get("__missing_file__").await.unwrap().is_none());
-    let test_file = directory.path().join("test");
-    tokio::fs::write(&test_file, b"test").await.unwrap();
-    assert!(fs.exists("test").await.unwrap());
-    assert!(fs.get("test").await.unwrap().is_some());
-
-    // Writes should fail but not error
-    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
-    assert!(!fs.exists("bob").await.unwrap());
-
-    // Deletes should fail but not error
-    assert!(fs.delete("test").await.is_ok());
-    assert!(fs.exists("test").await.unwrap());
+    read_only(url).await;
 }
 
 /// Test S3 FileStore using Minio by pushing and fetching back content from it.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_s3() {
     let content = Bytes::copy_from_slice(b"THIS IS A MINIO TEST");
-
-    let fs = FileStore::with_limit_retries("s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000/?s3_bucket=test&use_ssl=False").await.unwrap();
+    let url = "s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000/?s3_bucket=test&use_ssl=False";
+    let fs = FileStore::with_limit_retries(url).await.unwrap();
     assert!(fs.delete("al4_minio_pytest.txt").await.is_ok());
     assert!(fs.put("al4_minio_pytest.txt", &content).await.is_ok());
     assert!(fs.exists("al4_minio_pytest.txt").await.unwrap());
@@ -200,6 +128,7 @@ async fn test_s3() {
     assert!(fs.delete("al4_minio_pytest.txt").await.is_ok());
     common_actions(fs.clone()).await;
     big_file(fs).await;
+    read_only(url.to_string()).await;
 }
 
 /// Test S3 FileStore using Minio by pushing and fetching back content from it.
@@ -214,24 +143,6 @@ async fn test_s3_retry() {
         FileStore::open(&["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9111/?s3_bucket=test&use_ssl=False".to_string()])
     ).await;
     assert!(timeout.is_err());
-}
-
-/// Test S3 FileStore in read-only mode
-#[tokio::test(flavor = "multi_thread")]
-async fn test_s3_readonly() {
-    let fs = FileStore::with_limit_retries("s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000/?s3_bucket=test&use_ssl=False&read_only=true").await.unwrap();
-    assert!(fs.get("__missing_file__").await.unwrap().is_none());
-    assert!(fs.exists("test").await.unwrap());
-    assert!(fs.get("test").await.unwrap().is_some());
-    
-
-    // Writes should fail but not error
-    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
-    assert!(!fs.exists("bob").await.unwrap());
-
-    // Deletes should fail but not error
-    assert!(fs.delete("test").await.is_ok());
-    assert!(fs.exists("test").await.unwrap());    
 }
 
 async fn common_actions(fs: Arc<FileStore>) {
@@ -370,4 +281,34 @@ async fn parallel_activity(fs: Arc<FileStore>) {
         handle.await.unwrap();
         println!("finish");
     }
+}
+
+// Test that a FileStore in read-only mode properly disallows writes and deletes but still allows reads.
+async fn read_only(url: String) {
+    use url::Url;    
+    // Initialize with a single file for testing existence and retrieval
+    let fs = FileStore::with_limit_retries(&url).await.unwrap();
+    assert!(fs.put("test", &Bytes::copy_from_slice(b"test")).await.is_ok());
+
+    // Create a read-only FileStore instance used for the rest of the test
+    let mut ro_url = Url::parse(&url).unwrap();
+    ro_url.query_pairs_mut().append_pair("read_only", "true");
+    let fs_ro = FileStore::with_limit_retries(&ro_url.as_str()).await.unwrap();
+
+    assert!(fs.get("__missing_file__").await.unwrap().is_none());
+    assert!(fs_ro.exists("test").await.unwrap());
+    assert!(fs_ro.get("test").await.unwrap().is_some());
+    
+
+    // Writes should fail but not error
+    assert!(fs_ro.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
+    assert!(!fs_ro.exists("bob").await.unwrap());
+
+    // Deletes should fail but not error
+    assert!(fs_ro.delete("test").await.is_ok());
+    assert!(fs_ro.exists("test").await.unwrap());    
+
+
+    assert!(fs.get("__missing_file__").await.unwrap().is_none());
+    assert!(fs.exists("test").await.unwrap());
 }

--- a/assemblyline-filestore/src/tests/mod.rs
+++ b/assemblyline-filestore/src/tests/mod.rs
@@ -46,6 +46,26 @@ async fn test_azure_emulator() {
     big_file(fs).await;
 }
 
+/// test Azure filestore in read-only mode
+#[tokio::test(flavor = "multi_thread")]
+async fn test_azure_readonly() {
+    init();
+    let fs = FileStore::with_limit_retries("azure://alpytest.blob.core.windows.net/pytest/?read_only=true").await.unwrap();
+    println!("{fs:?}");
+
+    assert!(fs.get("__missing_file__").await.unwrap().is_none());
+    assert!(fs.exists("test").await.unwrap());
+    assert!(fs.get("test").await.unwrap().is_some());
+
+    // Writes should fail but not error
+    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
+    assert!(!fs.exists("bob").await.unwrap());
+
+    // Deletes should fail but not error
+    assert!(fs.delete("test").await.is_ok());
+    assert!(fs.exists("test").await.unwrap());    
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sftp() {
     init();
@@ -53,6 +73,27 @@ async fn test_sftp() {
     let fs = FileStore::with_limit_retries(&server).await.unwrap();
     common_actions(fs).await;
     // big_file(fs).await; VERY SLOW
+}
+
+/// Test SFTP filestore in read-only mode
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sftp_readonly() {
+    init();
+    let server = start_temp_sftp_server().await;
+    let fs = FileStore::with_limit_retries(&format!("sftp://{server}/?read_only=true")).await.unwrap();
+    
+    // Ensure that we can read files but not write or delete
+    assert!(fs.get("__missing_file__").await.unwrap().is_none());
+    assert!(fs.exists("test").await.unwrap());
+    assert!(fs.get("test").await.unwrap().is_some());
+
+    // Writes should fail but not error
+    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
+    assert!(!fs.exists("bob").await.unwrap());
+
+    // Deletes should fail but not error
+    assert!(fs.delete("test").await.is_ok());
+    assert!(fs.exists("test").await.unwrap());    
 }
 
 /// Run some operations against an in-process ftp server
@@ -74,6 +115,25 @@ async fn ftps() {
     let fs = FileStore::with_limit_retries(&format!("ftps://{temp_ftps_server}")).await.unwrap();
     common_actions(fs.clone()).await;
     big_file(fs).await;
+}
+
+// Test FTP filestore in read-only mode
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ftp_readonly() {
+    init();
+    let temp_ftp_server = start_temp_ftp_server(None).await;
+    let fs = FileStore::with_limit_retries(&format!("ftp://{temp_ftp_server}/?read_only=true")).await.unwrap();
+    assert!(fs.get("__missing_file__").await.unwrap().is_none());
+    assert!(fs.exists("test").await.unwrap());
+    assert!(fs.get("test").await.unwrap().is_some());
+
+    // Writes should fail but not error
+    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
+    assert!(!fs.exists("bob").await.unwrap());
+
+    // Deletes should fail but not error
+    assert!(fs.delete("test").await.is_ok());
+    assert!(fs.exists("test").await.unwrap());    
 }
 
 /// Run many parallel operations against an in-process ftp server
@@ -105,6 +165,28 @@ async fn test_file() {
     big_file(fs).await;
 }
 
+/// Test local filesystem based filestore in read-only mode
+#[tokio::test(flavor = "multi_thread")]
+async fn test_file_readonly() {
+    let directory = tempfile::tempdir().unwrap();
+    let url = format!("file://{}?read_only=true", directory.path().to_string_lossy());
+    println!("{url}");
+    let fs = FileStore::with_limit_retries(&url).await.unwrap();
+    assert!(fs.get("__missing_file__").await.unwrap().is_none());
+    let test_file = directory.path().join("test");
+    tokio::fs::write(&test_file, b"test").await.unwrap();
+    assert!(fs.exists("test").await.unwrap());
+    assert!(fs.get("test").await.unwrap().is_some());
+
+    // Writes should fail but not error
+    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
+    assert!(!fs.exists("bob").await.unwrap());
+
+    // Deletes should fail but not error
+    assert!(fs.delete("test").await.is_ok());
+    assert!(fs.exists("test").await.unwrap());
+}
+
 /// Test S3 FileStore using Minio by pushing and fetching back content from it.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_s3() {
@@ -120,7 +202,6 @@ async fn test_s3() {
     big_file(fs).await;
 }
 
-
 /// Test S3 FileStore using Minio by pushing and fetching back content from it.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_s3_retry() {
@@ -133,6 +214,24 @@ async fn test_s3_retry() {
         FileStore::open(&["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9111/?s3_bucket=test&use_ssl=False".to_string()])
     ).await;
     assert!(timeout.is_err());
+}
+
+/// Test S3 FileStore in read-only mode
+#[tokio::test(flavor = "multi_thread")]
+async fn test_s3_readonly() {
+    let fs = FileStore::with_limit_retries("s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000/?s3_bucket=test&use_ssl=False&read_only=true").await.unwrap();
+    assert!(fs.get("__missing_file__").await.unwrap().is_none());
+    assert!(fs.exists("test").await.unwrap());
+    assert!(fs.get("test").await.unwrap().is_some());
+    
+
+    // Writes should fail but not error
+    assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_ok());
+    assert!(!fs.exists("bob").await.unwrap());
+
+    // Deletes should fail but not error
+    assert!(fs.delete("test").await.is_ok());
+    assert!(fs.exists("test").await.unwrap());    
 }
 
 async fn common_actions(fs: Arc<FileStore>) {

--- a/assemblyline-filestore/src/tests/mod.rs
+++ b/assemblyline-filestore/src/tests/mod.rs
@@ -34,7 +34,6 @@ async fn test_azure() {
     assert!(fs.exists("test").await.unwrap());
     assert!(fs.get("test").await.unwrap().is_some());
     assert!(fs.put("bob", &Bytes::copy_from_slice(b"bob")).await.is_err());
-    read_only(url.to_string()).await;
 }
 
 /// test Azure filestore against the local emulator container

--- a/assemblyline-filestore/src/transport/azure.rs
+++ b/assemblyline-filestore/src/transport/azure.rs
@@ -75,10 +75,10 @@ pub struct TransportAzure {
 
 
 impl TransportAzure {
-    pub async fn new(host: String, base: String, parameters: AzureParameters, connection_attempts: Option<usize>) -> Result<Self> {
+    pub async fn new(host: String, base: String, parameters: AzureParameters, connection_attempts: Option<usize>, read_only: bool) -> Result<Self> {
 //     def __init__(self, base=None, access_key=None, tenant_id=None, client_id=None, client_secret=None,
 //                 host=None, connection_attempts=None, allow_directory_access=False, use_default_credentials=False):
-        let mut read_only = false;
+        let mut read_only = read_only;
         let AzureParameters {
             access_key,
             use_default_credentials,
@@ -145,14 +145,15 @@ impl TransportAzure {
             if !any_is_not_found(&err) {
                 return Err(err)
             }
-
-            if let Err(err) = retry!(connection_attempts, container_client.create().await) {
-                if !any_is_not_found(&err) {
-                    return Err(err)
+            if !read_only {
+                if let Err(err) = retry!(connection_attempts, container_client.create().await) {
+                    if !any_is_not_found(&err) {
+                        return Err(err)
+                    }
+                    info!("Failed to create container, we're most likely in read only mode");
+                    read_only = true;
                 }
-                info!("Failed to create container, we're most likely in read only mode");
-                read_only = true;
-            }    
+            }                
         }
 
         Ok(Self {
@@ -348,6 +349,10 @@ impl Transport for TransportAzure {
 //             # If its already not found, then consider it deleted.
 //             if not isinstance(error.cause, ResourceNotFoundError):
 //                 raise
+    }
+
+    fn read_only(&self) -> bool {
+        self.read_only
     }
 }
 

--- a/assemblyline-filestore/src/transport/ftp.rs
+++ b/assemblyline-filestore/src/transport/ftp.rs
@@ -32,7 +32,8 @@ struct FtpConnectionPool<T: TokioTlsStream + Send> {
     pool: parking_lot::Mutex<Vec<Client<T>>>,
     signal: tokio::sync::Notify,
 
-    retry_limit: Option<usize>
+    retry_limit: Option<usize>,
+    read_only: bool,
 }
 
 /// A single connection owned by the pool, loaned to a function call
@@ -77,7 +78,7 @@ impl<T: TokioTlsStream + Send> std::ops::DerefMut for Client<T> {
 
 
 impl<T: TokioTlsStream + Send> FtpConnectionPool<T> {
-    pub async fn new(tls: bool, base: &str, host: String, port: u16, user: Option<String>, password: Option<String>, retry_limit: Option<usize>) -> Result<Arc<Self>> {
+    pub async fn new(tls: bool, base: &str, host: String, port: u16, user: Option<String>, password: Option<String>, retry_limit: Option<usize>, read_only: bool) -> Result<Arc<Self>> {
         let new = Arc::new(Self {
             user,
             password,
@@ -89,7 +90,8 @@ impl<T: TokioTlsStream + Send> FtpConnectionPool<T> {
             pool: parking_lot::Mutex::new(vec![]),
             signal: tokio::sync::Notify::new(),
 
-            retry_limit
+            retry_limit,
+            read_only
         });
 
         // initiaize the pool with some connections
@@ -146,18 +148,18 @@ impl<T: TokioTlsStream + Send> std::fmt::Debug for TransportFtp<T> {
 
 impl TransportFtp<AsyncNoTlsStream> {
 
-    pub async fn new(retry_limit: Option<usize>, base: &str, host: String, port: u16, user: Option<String>, password: Option<String>) -> Result<Self> {
+    pub async fn new(retry_limit: Option<usize>, base: &str, host: String, port: u16, user: Option<String>, password: Option<String>, read_only: bool) -> Result<Self> {
         Ok(Self {
-            pool: FtpConnectionPool::new(false, base, host, port, user, password, retry_limit).await?,
+            pool: FtpConnectionPool::new(false, base, host, port, user, password, retry_limit, read_only).await?,
         })
     }
 }
 
 impl TransportFtp<AsyncNativeTlsStream> {
 
-    pub async fn new_secure(retry_limit: Option<usize>, base: &str, host: String, port: u16, user: Option<String>, password: Option<String>) -> Result<Self> {
+    pub async fn new_secure(retry_limit: Option<usize>, base: &str, host: String, port: u16, user: Option<String>, password: Option<String>, read_only: bool) -> Result<Self> {
         Ok(Self {
-            pool: FtpConnectionPool::new(true, base, host, port, user, password, retry_limit).await?,
+            pool: FtpConnectionPool::new(true, base, host, port, user, password, retry_limit, read_only).await?,
         })
     }
 }
@@ -312,6 +314,10 @@ impl<T: TokioTlsStream + Send + 'static> Transport for TransportFtp<T> {
             client.rm(&name).await
         })?;
         Ok(())
+    }
+
+    fn read_only(&self) -> bool {
+        self.pool.read_only
     }
 }
 

--- a/assemblyline-filestore/src/transport/local.rs
+++ b/assemblyline-filestore/src/transport/local.rs
@@ -13,11 +13,12 @@ use super::Transport;
 
 pub struct LocalTransport {
     path: PathBuf,
+    read_only: bool,
 }
 
 impl LocalTransport {
-    pub fn new(path: PathBuf) -> Self {
-        Self { path }
+    pub fn new(path: PathBuf, read_only: bool) -> Self {
+        Self { path, read_only }
     }
 
     fn normalize(&self, path: &str) -> Result<PathBuf> {
@@ -130,6 +131,10 @@ impl Transport for LocalTransport {
         }
         Ok(())
     }
+
+    fn read_only(&self) -> bool {
+        self.read_only
+    }    
 }
 
 impl std::fmt::Debug for LocalTransport {

--- a/assemblyline-filestore/src/transport/mod.rs
+++ b/assemblyline-filestore/src/transport/mod.rs
@@ -41,6 +41,10 @@ pub trait Transport: Send + Sync + std::fmt::Debug {
     async fn stream(&self, name: &str) -> Result<(u64, tokio::sync::mpsc::Receiver<Result<Bytes, std::io::Error>>)>;
 
     async fn delete(&self, name: &str) -> Result<()>;
+
+    fn read_only(&self) -> bool {
+        false
+    }
 }
 
 fn normalize_srl_path(path: &str) -> String {

--- a/assemblyline-filestore/src/transport/mod.rs
+++ b/assemblyline-filestore/src/transport/mod.rs
@@ -42,9 +42,7 @@ pub trait Transport: Send + Sync + std::fmt::Debug {
 
     async fn delete(&self, name: &str) -> Result<()>;
 
-    fn read_only(&self) -> bool {
-        false
-    }
+    fn read_only(&self) -> bool;
 }
 
 fn normalize_srl_path(path: &str) -> String {

--- a/assemblyline-filestore/src/transport/s3.rs
+++ b/assemblyline-filestore/src/transport/s3.rs
@@ -80,13 +80,14 @@ pub struct TransportS3 {
     _accesskey: Option<String>,
     host: String,
     port: u16,
+    read_only: bool,
 }
 
 
 impl TransportS3 {
     // base=None, , aws_region=None, host=None, port=None, ):
 
-    pub async fn new(base: String, host: Option<String>, port: Option<u16>, accesskey: Option<String>, secretkey: Option<String>, connection_attempts: Option<usize>, parameters: S3Parameters) -> Result<Self> {
+    pub async fn new(base: String, host: Option<String>, port: Option<u16>, accesskey: Option<String>, secretkey: Option<String>, connection_attempts: Option<usize>, parameters: S3Parameters, read_only: bool) -> Result<Self> {
         let host = host.unwrap_or_else(|| DEFAULT_HOST.to_owned());
 
         let port = match port {
@@ -203,18 +204,20 @@ impl TransportS3 {
             let err = err.downcast::<SdkError<aws_sdk_s3::operation::head_bucket::HeadBucketError>>()?;
             let err = err.into_service_error();
             if err.is_not_found() {
-                // if the bucket does not exist, create it
-                let create_result = retry!(connection_attempts, {
-                    client.create_bucket().bucket(&parameters.s3_bucket).send().await
-                });
-                if let Err(err) = create_result {
-                    let err = err.downcast::<SdkError<aws_sdk_s3::operation::create_bucket::CreateBucketError>>()?;
-                    let x = err.into_service_error();
-                    // Maybe someone else created the bucket in the tibe between us calling head and create.
-                    if !x.is_bucket_already_exists() && !x.is_bucket_already_owned_by_you() {
-                        return Err(x.into())
+                // if the bucket does not exist, create it if it's not a read-only transport
+                if !read_only{
+                    let create_result = retry!(connection_attempts, {
+                        client.create_bucket().bucket(&parameters.s3_bucket).send().await
+                    });
+                    if let Err(err) = create_result {
+                        let err = err.downcast::<SdkError<aws_sdk_s3::operation::create_bucket::CreateBucketError>>()?;
+                        let x = err.into_service_error();
+                        // Maybe someone else created the bucket in the tibe between us calling head and create.
+                        if !x.is_bucket_already_exists() && !x.is_bucket_already_owned_by_you() {
+                            return Err(x.into())
+                        }
                     }
-                }
+                }                
             } else {
                 return Err(anyhow::Error::new(err).context("head error"))
             }
@@ -228,6 +231,7 @@ impl TransportS3 {
             client,
             host,
             port,
+            read_only
         })
     }
 
@@ -381,6 +385,10 @@ impl Transport for TransportS3 {
                 .send().await
         })
     }
+    
+    fn read_only(&self) -> bool {
+        self.read_only
+    }    
 }
 
 

--- a/assemblyline-filestore/src/transport/sftp.rs
+++ b/assemblyline-filestore/src/transport/sftp.rs
@@ -27,6 +27,7 @@ pub struct TransportSftp {
     base: String,
     client: SftpSession,
     retry_limit: Option<usize>,
+    read_only: bool
 }
 
 impl std::fmt::Debug for TransportSftp {
@@ -63,7 +64,7 @@ pub struct SftpParameters {
 
 
 impl TransportSftp {
-    pub async fn new(base: String, host: String, password: Option<String>, user: String, port: u16, retry_limit: Option<usize>, params: SftpParameters) -> Result<Self> {
+    pub async fn new(base: String, host: String, password: Option<String>, user: String, port: u16, retry_limit: Option<usize>, params: SftpParameters, read_only: bool) -> Result<Self> {
         // let base = if base == "/" { "".to_owned() } else { base };
 
         debug!("SFTP to {user}@{host}:{port}{base}; password ({}), private_key ({})", password.is_some(), params.private_key.is_some());
@@ -108,6 +109,7 @@ impl TransportSftp {
             port,
             user,
             retry_limit,
+            read_only
         })
     }
 
@@ -256,6 +258,10 @@ impl Transport for TransportSftp {
     async fn delete(&self, name: &str) -> Result<()> {
         retry!(self.retry_limit, self._delete(name).await)
     }
+
+    fn read_only(&self) -> bool {
+        self.read_only
+    }    
 }
 
 

--- a/assemblyline-models/src/config.rs
+++ b/assemblyline-models/src/config.rs
@@ -1131,8 +1131,6 @@ pub struct Filestore {
     pub cache: Vec<String>,
     /// List of filestores used for storage
     pub storage: Vec<String>,
-    /// List of filestores used as read-only fallback for storage (e.g. legacy backends with unmigrated data)
-    pub readonly_storage: Vec<String>,
 }
 
 impl Default for Filestore {
@@ -1141,7 +1139,6 @@ impl Default for Filestore {
             archive: vec!["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000?s3_bucket=al-archive&use_ssl=False".to_string()],
             cache: vec!["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000?s3_bucket=al-cache&use_ssl=False".to_string()],
             storage: vec!["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000?s3_bucket=al-storage&use_ssl=False".to_string()],
-            readonly_storage: vec![],
         }
     }
 }

--- a/assemblyline-models/src/config.rs
+++ b/assemblyline-models/src/config.rs
@@ -1131,6 +1131,8 @@ pub struct Filestore {
     pub cache: Vec<String>,
     /// List of filestores used for storage
     pub storage: Vec<String>,
+    /// List of filestores used as read-only fallback for storage (e.g. legacy backends with unmigrated data)
+    pub readonly_storage: Vec<String>,
 }
 
 impl Default for Filestore {
@@ -1138,7 +1140,8 @@ impl Default for Filestore {
         Self {
             archive: vec!["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000?s3_bucket=al-archive&use_ssl=False".to_string()],
             cache: vec!["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000?s3_bucket=al-cache&use_ssl=False".to_string()],
-            storage: vec!["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000?s3_bucket=al-storage&use_ssl=False".to_string()]
+            storage: vec!["s3://al_storage_key:Ch@ngeTh!sPa33w0rd@localhost:9000?s3_bucket=al-storage&use_ssl=False".to_string()],
+            readonly_storage: vec![],
         }
     }
 }

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -253,11 +253,7 @@ impl Core {
         let datastore = Elastic::connect(&config.datastore.hosts[0], false, datastore_ca, !datastore_verify, elastic_prefix).await?;
 
         // connect to filestore
-        let filestore = if config.filestore.readonly_storage.is_empty() {
-            FileStore::open(&config.filestore.storage).await.context("initializing filestore")?
-        } else {
-            FileStore::open_with_readonly(&config.filestore.storage, &config.filestore.readonly_storage).await.context("initializing filestore with readonly backends")?
-        };
+        let filestore = FileStore::open(&config.filestore.storage).await.context("initializing filestore")?;
 
         //
         let file_cache = FileStore::open(&config.filestore.cache).await.context("initializing cache filestore")?;
@@ -457,4 +453,3 @@ impl Drop for TestGuard {
 /// A convenience trait that lets you pass true, false, or None for boolean arguments
 pub trait IBool: Into<Option<bool>> + Copy + Send {}
 impl<T: Into<Option<bool>> + Copy + Send> IBool for T {}
-

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -253,7 +253,11 @@ impl Core {
         let datastore = Elastic::connect(&config.datastore.hosts[0], false, datastore_ca, !datastore_verify, elastic_prefix).await?;
 
         // connect to filestore
-        let filestore = FileStore::open(&config.filestore.storage).await.context("initializing filestore")?;
+        let filestore = if config.filestore.readonly_storage.is_empty() {
+            FileStore::open(&config.filestore.storage).await.context("initializing filestore")?
+        } else {
+            FileStore::open_with_readonly(&config.filestore.storage, &config.filestore.readonly_storage).await.context("initializing filestore with readonly backends")?
+        };
 
         //
         let file_cache = FileStore::open(&config.filestore.cache).await.context("initializing cache filestore")?;


### PR DESCRIPTION
## Problem

When multiple storage backends are configured (e.g. primary + legacy), every upload/put/delete writes to ALL transports sequentially. This causes 2x I/O amplification under high load, saturating the service-server and triggering cascading task timeouts that result in services being killed with 'terminated unexpectedly' errors.

## Solution

Separates writable and read-only transport pools in FileStore:

- **Write operations** (upload, put, delete) only target writable transports
- **Read operations** (download, get, exists, stream) search both pools, falling back to read-only transports for data that hasn't been migrated to the primary storage

### Changes

- **assemblyline-models/config.rs**: Add \eadonly_storage: Vec<String>\ field to \Filestore\ config (defaults to empty)
- **assemblyline-filestore/filestore.rs**: Split transports into writable and readonly pools, add \open_with_readonly()\ constructor
- **assemblyline-server/main.rs**: Use \open_with_readonly()\ when \eadonly_storage\ is configured

### Configuration Example

\\\yaml
filestore:
  storage:
    - 'azure://primary.blob.core.windows.net/samples?use_default_credentials=True'
  readonly_storage:
    - 'azure://legacy.blob.core.windows.net/samples?use_default_credentials=True'
\\\

### Related PRs

- Python assemblyline-base: CybercentreCanada/assemblyline-base#2136 (equivalent feature)