### PR TITLE
feat(server): add flag-gated OpenTelemetry OTLP layer alongside Elastic APM

### DIFF
--- a/assemblyline-models/src/config.rs
+++ b/assemblyline-models/src/config.rs
@@ -1186,6 +1186,10 @@ pub struct Logging {
     pub log_as_json: bool,
     // /// Add a health check to core components.<br>If `true`, core components will touch this path regularly to tell the container environment it is healthy
     // pub heartbeat_file: str = odm.Optional(odm.Keyword(),")
+    /// Enable OpenTelemetry trace export
+    pub enable_opentelemetry: bool,
+    /// OpenTelemetry collector endpoint (OTLP gRPC), e.g. http://otel-collector:4317
+    pub opentelemetry_endpoint: Option<String>,
 }
 
 impl Default for Logging {
@@ -1200,6 +1204,8 @@ impl Default for Logging {
             syslog_host: "localhost".to_owned(),
             syslog_port: 514,
             syslog_transport: SyslogTransport::Tcp,
+            enable_opentelemetry: false,
+            opentelemetry_endpoint: None,
             // export_interval: 5,
             // heartbeat_file: "/tmp/heartbeat"
         }

--- a/assemblyline-server/Cargo.toml
+++ b/assemblyline-server/Cargo.toml
@@ -16,8 +16,12 @@ local-ip-address = "0.6"
 
 # Metric collection
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features=false, features=["std", "fmt"]}
+tracing-subscriber = { version = "0.3", default-features=false, features=["std", "fmt", "registry", "env-filter"]}
 tracing-elastic-apm = "3.4"
+opentelemetry = { version = "0.29", features = ["trace"] }
+opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.29", features = ["tonic", "grpc-tonic"] }
+tracing-opentelemetry = "0.30"
 
 # Utilities
 chrono = "0.4"

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -76,6 +76,10 @@ struct Args {
     #[arg(short, long)]
     enable_apm: bool,
 
+    /// Enable OpenTelemetry exporting (overrides config.logging.enable_opentelemetry)
+    #[arg(long)]
+    enable_otel: bool,
+
     #[command(subcommand)]
     pub command: Commands
 }
@@ -140,6 +144,30 @@ async fn main() -> ExitCode {
         info!("APM collection not configured");
     }
 
+    // Configure OpenTelemetry (flag-gated, runs alongside APM if both enabled)
+    let _otel_guard = {
+        let otel_enabled = args.enable_otel || config.logging.enable_opentelemetry;
+        if otel_enabled {
+            let endpoint = config.logging.opentelemetry_endpoint.clone()
+                .or_else(|| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok())
+                .unwrap_or_else(|| "http://localhost:4317".to_string());
+
+            match init_opentelemetry(args.command.label(), &endpoint) {
+                Ok(guard) => {
+                    info!("OpenTelemetry exporter enabled -> {endpoint}");
+                    Some(guard)
+                }
+                Err(err) => {
+                    error!("Failed to initialize OpenTelemetry: {err}");
+                    None
+                }
+            }
+        } else {
+            info!("OpenTelemetry not enabled");
+            None
+        }
+    };
+
     // Connect to all the supporting components
     let core = match Core::setup(config, "", args.secure_connections).await {
         Ok(core) => core,
@@ -173,6 +201,52 @@ async fn main() -> ExitCode {
             return ExitCode::FAILURE;
         },
     }
+}
+
+/// Guard that flushes and shuts down the OTEL tracer provider on drop.
+struct OtelGuard(opentelemetry_sdk::trace::SdkTracerProvider);
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.0.shutdown() {
+            eprintln!("OpenTelemetry shutdown error: {err}");
+        }
+    }
+}
+
+/// Initialize an OpenTelemetry OTLP exporter and install it as a tracing subscriber layer.
+fn init_opentelemetry(service_name: &str, endpoint: &str) -> Result<OtelGuard> {
+    use opentelemetry::trace::TracerProvider;
+    use opentelemetry_otlp::SpanExporter;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use opentelemetry_sdk::Resource;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()?;
+
+    let resource = Resource::builder()
+        .with_service_name(service_name.to_string())
+        .build();
+
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    let tracer = provider.tracer("assemblyline");
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    tracing_subscriber::registry()
+        .with(otel_layer)
+        .with(tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")))
+        .init();
+
+    Ok(OtelGuard(provider))
 }
 
 

--- a/assemblyline-server/src/service_api/helpers/tasking.rs
+++ b/assemblyline-server/src/service_api/helpers/tasking.rs
@@ -24,6 +24,7 @@ use parking_lot::Mutex;
 use redis_objects::{increment, AutoExportingMetrics, Hashmap, RedisObjects};
 use serde_json::{json, Value};
 use thiserror::Error;
+use tracing::instrument;
 
 use crate::service_api::v1::task::models::{Result as ApiResult};
 use crate::common::heuristics::{HeuristicHandler, InvalidHeuristicException};
@@ -163,6 +164,7 @@ impl TaskingClient {
         })
     }
 
+    #[instrument(skip(self, file), fields(sha256 = expected_sha256))]
     pub async fn upload_file(&self, file: &Path, classification: &str, ttl: u32, is_section_image: bool, is_supplementary: bool, expected_sha256: &str) -> Result<()> {
         // Identify the file info of the uploaded file
         let file_info = self.identify.fileinfo(file.to_path_buf(), true, None, None).await.context("fileinfo")?;
@@ -535,6 +537,7 @@ impl From<redis_objects::ErrorTypes> for RegisterError {
 }
 
 impl TaskingClient {
+    #[instrument(skip(self, service_tool_version, status_expiry, timeout))]
     pub async fn get_task(&self, client_id: &str, service_name: ServiceName, service_version: &str, service_tool_version: Option<&str>, status_expiry: Option<f64>, timeout: Duration) -> Result<(Option<Task>, bool)> {
         let metric_factory = self.get_metrics_factory(service_name);
         let start_time = std::time::Instant::now();
@@ -776,6 +779,7 @@ fn finish_parsing_task(mut data: JsonMap) -> Result<Task, MalformedResult> {
 
 impl TaskingClient {
 
+    #[instrument(skip(self, service_task))]
     pub async fn task_finished(&self, service_task: FinishedBody, client_id: &str, service_name: ServiceName) -> Result<Value> {
         match service_task {
             FinishedBody::Success(mut success) => {
@@ -814,6 +818,7 @@ impl TaskingClient {
         }
     }
 
+    #[instrument(skip(self, success))]
     async fn _handle_task_result(&self,
         task: Task,
         success: Box<TaskSuccess>,

--- a/assemblyline-server/src/service_api/v1/file.rs
+++ b/assemblyline-server/src/service_api/v1/file.rs
@@ -20,6 +20,7 @@ use poem::web::{Data, Multipart, Path};
 use poem::{get, handler, put, Body, Endpoint, EndpointExt, Result, Response, Route};
 use serde_json::json;
 use tokio_stream::wrappers::ReceiverStream;
+use tracing::instrument;
 
 use crate::service_api::helpers::auth::{ClientInfo, ServiceAuth};
 use crate::service_api::helpers::tasking::TaskingClient;
@@ -55,6 +56,7 @@ pub fn api(auth: ServiceAuth) -> impl Endpoint {
 ///
 /// Result example:
 /// <THE FILE BINARY>
+#[instrument(skip(core))]
 #[handler]
 async fn download_file(Path(sha256): Path<String>, client_info: Data<&ClientInfo>, core: Data<&Arc<Core>>) -> Result<Response> {
     let sha256: Sha256 = match sha256.parse() {
@@ -98,6 +100,7 @@ async fn download_file(Path(sha256): Path<String>, client_info: Data<&ClientInfo
 ///
 /// Result example:
 /// {"success": true}
+#[instrument(skip(tasking, multipart_body, stream_body))]
 #[handler]
 async fn upload_file(
     client_info: Data<&ClientInfo>,

--- a/assemblyline-server/src/service_api/v1/task.rs
+++ b/assemblyline-server/src/service_api/v1/task.rs
@@ -19,6 +19,7 @@ use poem::{get, handler, Endpoint, EndpointExt, Result, Response, Route};
 use poem::web::{Data, Json};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use tracing::instrument;
 
 use crate::service_api::helpers::auth::{ClientInfo, ServiceAuth};
 use crate::service_api::helpers::{make_api_error, make_api_response, make_empty_api_error};
@@ -48,6 +49,7 @@ pub fn api(auth: ServiceAuth) -> impl Endpoint {
 ///
 /// Result example:
 /// {'keep_alive': true}
+#[instrument(skip(tasking, headers))]
 #[handler]
 async fn get_task(
     tasking: Data<&Arc<TaskingClient>>,
@@ -126,6 +128,7 @@ async fn get_task(
 ///  "result": <AL Result Dict>,
 ///  "freshen": true
 /// }
+#[instrument(skip(tasking, body))]
 #[handler]
 async fn task_finished(
     Data(client_info): Data<&ClientInfo>,


### PR DESCRIPTION
## Summary
- add optional OpenTelemetry OTLP exporter wiring to ssemblyline-server
- keep existing Elastic APM path intact and allow both to run concurrently
- gate OTEL via config/CLI so behavior is unchanged by default
- add tracing #[instrument] spans on key service API task/file flows

## Config and Runtime Controls
- logging.enable_opentelemetry (default: alse)
- logging.opentelemetry_endpoint (default: http://localhost:4317)
- CLI override: --enable-otel
- env fallback for endpoint: OTEL_EXPORTER_OTLP_ENDPOINT

## Files Changed
- ssemblyline-server/Cargo.toml
- ssemblyline-server/src/main.rs
- ssemblyline-server/src/service_api/helpers/tasking.rs
- ssemblyline-server/src/service_api/v1/task.rs
- ssemblyline-server/src/service_api/v1/file.rs
- ssemblyline-models/src/config.rs

## Notes
- OTEL is disabled by default, preserving current behavior unless explicitly enabled.
- Due local Windows toolchain constraints in this environment (link.exe missing), full cargo check could not be completed here.