### PR TITLE
fix(azure): verify blob exists before starting download stream

### DIFF
--- a/assemblyline-filestore/src/transport/azure.rs
+++ b/assemblyline-filestore/src/transport/azure.rs
@@ -295,6 +295,14 @@ impl Transport for TransportAzure {
     async fn stream(&self, name: &str) -> Result<(u64, tokio::sync::mpsc::Receiver<Result<Bytes, std::io::Error>>)> {
         let key = self.normalize(name);
         let client = self.container_client.blob_client(key);
+
+        // Verify the blob exists and get its size BEFORE starting the download stream.
+        // This avoids spawning a background task for a blob that doesn't exist and
+        // ensures callers receive a proper not-found error they can handle (e.g. by
+        // trying the next transport in a multi-transport FileStore).
+        let properties = client.get_properties().await?;
+        let content_length = properties.blob.properties.content_length;
+
         let mut stream = client.get().into_stream();
         let (send, recv) = tokio::sync::mpsc::channel(8);
         tokio::spawn(async move {
@@ -322,9 +330,8 @@ impl Transport for TransportAzure {
                 };
             }
         });
-        
-        let properties = client.get_properties().await?;
-        Ok((properties.blob.properties.content_length, recv))
+
+        Ok((content_length, recv))
     }
 
     async fn delete(&self, name: &str) -> Result<()> {


### PR DESCRIPTION
The Azure transport's stream() called client.get().into_stream() and spawned a background read task BEFORE calling get_properties() to verify the blob exists. This caused two problems:

1. For a not-found blob, a background tokio task was spawned that would emit an error chunk on the channel - wasted work and a brief resource leak (channel + task).

2. The not-found error from get_properties() was returned only after spawning the task, but the spawned task could race and produce confusing error states.

Reordering to check existence FIRST means callers (e.g. the multi- transport FileStore::stream wrapper) get a clean not-found error and can fall through to the next transport without a spawned task being left dangling for the failed lookup.