### PR TITLE
Add OpenSearch support and backend auto-detection

### DIFF
--- a/assemblyline-models/src/config.rs
+++ b/assemblyline-models/src/config.rs
@@ -1057,13 +1057,17 @@ impl Default for Archive {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all="lowercase")]
 pub enum DatastoreType {
-    Elasticsearch
+    Elasticsearch,
+    Opensearch,
+    Auto,
 }
 
 #[test]
 fn test_datastore_type_serialization() {
     assert_eq!(serde_json::to_string(&DatastoreType::Elasticsearch).unwrap(), "\"elasticsearch\"");
     assert_eq!(serde_json::from_str::<DatastoreType>("\"elasticsearch\"").unwrap(), DatastoreType::Elasticsearch);
+    assert_eq!(serde_json::from_str::<DatastoreType>("\"opensearch\"").unwrap(), DatastoreType::Opensearch);
+    assert_eq!(serde_json::from_str::<DatastoreType>("\"auto\"").unwrap(), DatastoreType::Auto);
     assert_eq!(serde_json::to_value(DatastoreType::Elasticsearch).unwrap(), serde_json::json!("elasticsearch"));
     // assert_eq!(serde_json::from_str::<DatastoreType>("\"Elasticsearch\"").unwrap(), DatastoreType::Elasticsearch);
 

--- a/assemblyline-server/docker-compose.yaml
+++ b/assemblyline-server/docker-compose.yaml
@@ -21,6 +21,19 @@ services:
     ports:
       - "9200:9200"
 
+  opensearch:
+    image: opensearchproject/opensearch:2.19.1
+    profiles:
+      - opensearch
+    tmpfs:
+      - /usr/share/opensearch/data
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m"
+    ports:
+      - "9201:9200"
+
   redis:
     image: redis
     ports:

--- a/assemblyline-server/src/elastic/collection.rs
+++ b/assemblyline-server/src/elastic/collection.rs
@@ -23,7 +23,7 @@ use crate::elastic::{responses, DEFAULT_SEARCH_FIELD, KEEP_ALIVE};
 use super::bulk::TypedBulkPlan;
 use super::pit::PitGuard;
 use super::responses::DeleteResult;
-use super::{parse_sort, CopyMethod, ElasticError, ElasticHelper, Index, Request, Result, SortDirection, Version};
+use super::{mapping_for_backend, parse_sort, CopyMethod, ElasticError, ElasticHelper, Index, Request, Result, SortDirection, Version};
 use super::error::{ElasticErrorInner, WithContext};
 
 pub (super) const DEFAULT_SORT: &str = "_id asc";
@@ -80,6 +80,7 @@ impl<T: CollectionType> Collection<T> {
 
                 let mut mapping = assemblyline_models::meta::build_mapping::<T>().map_err(ElasticError::fatal)?;
                 mapping.apply_defaults();
+                let mapping = mapping_for_backend(&mapping, self.database.backend)?;
 
                 let body = json!({
                     "mappings": mapping,
@@ -289,6 +290,7 @@ impl<T: CollectionType> Collection<T> {
         for index in self.get_index_list(None)? {
             // self.with_retries(self.datastore.client.indices.put_mapping, index=index, properties=properties)
             let request = Request::put_index_mapping(&self.database.host, &index)?;
+            let properties = mapping_for_backend(&properties, self.database.backend)?;
             self.database.make_request_json(&mut 0, &request, &json!({
                 "properties": properties
             })).await?;
@@ -318,6 +320,7 @@ impl<T: CollectionType> Collection<T> {
                 //                 settings=self._get_index_settings(archive=archive))
                 let mut mapping = assemblyline_models::meta::build_mapping::<T>().map_err(ElasticError::fatal)?;
                 mapping.apply_defaults();
+                let mapping = mapping_for_backend(&mapping, self.database.backend)?;
 
                 let body = json!({
                     "mappings": mapping,

--- a/assemblyline-server/src/elastic/mod.rs
+++ b/assemblyline-server/src/elastic/mod.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use assemblyline_models::datastore::apikey::Apikey;
+use assemblyline_models::config::DatastoreType;
 use assemblyline_models::datastore::badlist::Badlist;
 use assemblyline_models::datastore::heuristic::Heuristic;
 use assemblyline_models::datastore::safelist::Safelist;
@@ -25,6 +26,8 @@ mod test_datastore;
 mod test_mapping;
 #[cfg(test)]
 mod test_helper;
+#[cfg(test)]
+mod test_backend;
 
 use assemblyline_markings::classification::ClassificationParser;
 use assemblyline_models::datastore::filescore::FileScore;
@@ -54,6 +57,19 @@ pub enum Index {
 pub enum Version {
     Create,
     Expected{primary_term: i64, sequence_number: i64},
+}
+
+/// A resolved datastore backend. `auto` is deliberately not represented here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    Elasticsearch,
+    Opensearch,
+}
+
+impl Backend {
+    pub(crate) fn supports_task_index_cleanup(self) -> bool {
+        self == Self::Elasticsearch
+    }
 }
 
 const ALT_ELASTICSEARCH_USERS: &[&str] = &["plumber"];
@@ -99,6 +115,33 @@ fn strip_nulls(d: serde_json::Value) -> serde_json::Value {
             json!(out)
         },
         value => value
+    }
+}
+
+fn mapping_for_backend<T: Serialize>(mapping: &T, backend: Backend) -> Result<serde_json::Value> {
+    let mut value = serde_json::to_value(mapping)?;
+    if backend == Backend::Opensearch {
+        convert_wildcards_to_keywords(&mut value);
+    }
+    Ok(value)
+}
+
+fn convert_wildcards_to_keywords(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                convert_wildcards_to_keywords(value);
+            }
+        }
+        serde_json::Value::Object(values) => {
+            if values.get("type").and_then(serde_json::Value::as_str) == Some("wildcard") {
+                values.insert("type".to_owned(), json!("keyword"));
+            }
+            for value in values.values_mut() {
+                convert_wildcards_to_keywords(value);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -438,6 +481,7 @@ pub struct ElasticHelper {
     // pub es: tokio::sync::RwLock<elasticsearch::Elasticsearch>,
     pub host: url::Url,
     pub archive_access: bool,
+    pub backend: Backend,
 }
 
 impl std::fmt::Debug for ElasticHelper {
@@ -448,6 +492,16 @@ impl std::fmt::Debug for ElasticHelper {
 
 impl ElasticHelper {
     async fn connect(url: &str, archive_access: bool, ca_cert: Option<&[u8]>, connect_unsafe: bool) -> Result<Self> {
+        Self::connect_with_backend(
+            url,
+            archive_access,
+            ca_cert,
+            connect_unsafe,
+            DatastoreType::Elasticsearch,
+        ).await
+    }
+
+    async fn connect_with_backend(url: &str, archive_access: bool, ca_cert: Option<&[u8]>, connect_unsafe: bool, configured_backend: DatastoreType) -> Result<Self> {
         let host: url::Url = url.parse()?;
         let mut builder = reqwest::Client::builder()
             .timeout(get_transport_timeout());
@@ -463,12 +517,61 @@ impl ElasticHelper {
             builder = builder.danger_accept_invalid_certs(true);
         }
 
+        let client = builder.build().map_err(ElasticError::fatal)?;
+        let backend = match configured_backend {
+            DatastoreType::Elasticsearch => Backend::Elasticsearch,
+            DatastoreType::Opensearch => Backend::Opensearch,
+            DatastoreType::Auto => Self::detect_backend(&client, &host).await?,
+        };
+
         Ok(ElasticHelper{
             // es: tokio::sync::RwLock::new(Self::_create_connection(host.clone())?),
-            client: builder.build().map_err(ElasticError::fatal)?,
+            client,
             host,
             archive_access,
+            backend,
         })
+    }
+
+    async fn detect_backend(client: &reqwest::Client, host: &url::Url) -> Result<Backend> {
+        let response = client.get(host.clone()).send().await.map_err(|err| {
+            if err.is_connect() || err.is_timeout() {
+                ElasticError::fatal("Datastore backend detection connection failure")
+            } else {
+                ElasticError::fatal("Datastore backend detection request failure")
+            }
+        })?;
+
+        if response.status() == StatusCode::UNAUTHORIZED || response.status() == StatusCode::FORBIDDEN {
+            return Err(ElasticError::fatal(format!(
+                "Datastore backend detection authentication failure (HTTP {})",
+                response.status()
+            )))
+        }
+        if !response.status().is_success() {
+            return Err(ElasticError::fatal(format!(
+                "Datastore backend detection failed with HTTP {}",
+                response.status()
+            )))
+        }
+
+        let elasticsearch_header = response.headers()
+            .get("x-elastic-product")
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.eq_ignore_ascii_case("Elasticsearch"));
+        let body: serde_json::Value = response.json().await
+            .map_err(|err| ElasticError::fatal(format!("Malformed datastore backend detection response: {err}")))?;
+        let opensearch_metadata = body.pointer("/version/distribution")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| value.eq_ignore_ascii_case("opensearch"));
+
+        match (elasticsearch_header, opensearch_metadata) {
+            (true, false) => Ok(Backend::Elasticsearch),
+            (false, true) => Ok(Backend::Opensearch),
+            _ => Err(ElasticError::fatal(
+                "Unsupported or ambiguous datastore backend response"
+            )),
+        }
     }
 
     fn change_host(&self, url: url::Url) -> Self {
@@ -476,6 +579,7 @@ impl ElasticHelper {
             client: self.client.clone(),
             host: url,
             archive_access: self.archive_access,
+            backend: self.backend,
         }
     }
 
@@ -1010,7 +1114,11 @@ impl std::fmt::Debug for Elastic {
 
 impl Elastic {
     pub async fn connect(url: &str, archive_access: bool, ca_cert: Option<&[u8]>, connect_unsafe: bool, prefix: &str) -> Result<Arc<Self>> {
-        let helper = Arc::new(ElasticHelper::connect(url, archive_access, ca_cert, connect_unsafe).await?);
+        Self::connect_with_backend(url, archive_access, ca_cert, connect_unsafe, prefix, DatastoreType::Elasticsearch).await
+    }
+
+    pub async fn connect_with_backend(url: &str, archive_access: bool, ca_cert: Option<&[u8]>, connect_unsafe: bool, prefix: &str, backend: DatastoreType) -> Result<Arc<Self>> {
+        let helper = Arc::new(ElasticHelper::connect_with_backend(url, archive_access, ca_cert, connect_unsafe, backend).await?);
         Self::setup(helper, prefix).await
     }
 
@@ -1110,6 +1218,10 @@ impl Elastic {
     }
 
     pub async fn task_cleanup(&self, deleteable_task_age: Option<chrono::TimeDelta>, max_tasks: Option<u64>) -> Result<u64> {
+        // OpenSearch does not expose task history as a writable `.tasks` system index.
+        if !self.es.backend.supports_task_index_cleanup() {
+            return Ok(0)
+        }
         let deleteable_task_age = deleteable_task_age.unwrap_or(chrono::TimeDelta::zero());
 
         // Create the query to delete the tasks
@@ -1127,6 +1239,10 @@ impl Elastic {
 
         // return the number of deleted items
         return Ok(res._status.deleted)
+    }
+
+    pub(crate) fn backend(&self) -> Backend {
+        self.es.backend
     }
 
     // pub async fn update_service_delta(&self, name: &str, delta: &JsonMap) -> Result<()> {
@@ -1419,4 +1535,3 @@ fn extract_number(container: &JsonMap, name: &str) -> u64 {
         None => 0,
     }
 }
-

--- a/assemblyline-server/src/elastic/pit.rs
+++ b/assemblyline-server/src/elastic/pit.rs
@@ -7,6 +7,12 @@ use super::{responses, ElasticHelper, Request, Result};
 
 pub (super) const PIT_KEEP_ALIVE: &str = "5m";
 
+pub(super) fn close_body(backend: super::Backend, id: String) -> serde_json::Value {
+    match backend {
+        super::Backend::Elasticsearch => json!({"id": id}),
+        super::Backend::Opensearch => json!({"pit_id": [id]}),
+    }
+}
 
 pub (super) struct PitGuard {
     helper: Arc<ElasticHelper>,
@@ -15,15 +21,14 @@ pub (super) struct PitGuard {
 
 impl PitGuard {
     pub async fn open(helper: Arc<ElasticHelper>, index: &str) -> Result<Self> {
-        let response = helper.make_request(&mut 0, &Request::create_pit(&helper.host, index, PIT_KEEP_ALIVE)?).await?;
+        let response = helper.make_request(&mut 0, &Request::create_pit(&helper.host, index, PIT_KEEP_ALIVE, helper.backend)?).await?;
         let pit: responses::OpenPit = response.json().await?;
         Ok(Self { helper, id: pit.id })
     }
 
     async fn close(helper: Arc<ElasticHelper>, id: String) -> Result<()> {
-        let response = helper.make_request_json(&mut 0, &Request::delete_pit(&helper.host)?, &json!({
-            "id": id
-        })).await?;
+        let body = close_body(helper.backend, id);
+        let response = helper.make_request_json(&mut 0, &Request::delete_pit(&helper.host, helper.backend)?, &body).await?;
         let _body: responses::ClosePit = response.json().await?;
         Ok(())
     }

--- a/assemblyline-server/src/elastic/request.rs
+++ b/assemblyline-server/src/elastic/request.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use reqwest::Method;
-use super::{CopyMethod, Result};
+use super::{Backend, CopyMethod, Result};
 
 /// The header section and local parameters to a request to elasticsearch.
 /// 
@@ -176,8 +176,12 @@ impl Request {
         Ok(Self::new(Method::POST, host.join("_bulk")?, None))
     }
 
-    pub fn create_pit(host: &reqwest::Url, index: &str, keep_alive: &str) -> Result<Self> {
-        let mut url = host.join(&format!("{index}/_pit"))?;
+    pub fn create_pit(host: &reqwest::Url, index: &str, keep_alive: &str, backend: Backend) -> Result<Self> {
+        let path = match backend {
+            Backend::Elasticsearch => format!("{index}/_pit"),
+            Backend::Opensearch => format!("{index}/_search/point_in_time"),
+        };
+        let mut url = host.join(&path)?;
         url.query_pairs_mut().append_pair("keep_alive", keep_alive);
         Ok(Self::new(Method::POST, url, Some(index.to_owned())))
     }
@@ -214,8 +218,12 @@ impl Request {
         Ok(Self::new(Method::POST, url, None))
     }    
 
-    pub fn delete_pit(host: &reqwest::Url) -> Result<Self> {
-        Ok(Self::new(Method::DELETE, host.join("/_pit")?, None))
+    pub fn delete_pit(host: &reqwest::Url, backend: Backend) -> Result<Self> {
+        let path = match backend {
+            Backend::Elasticsearch => "/_pit",
+            Backend::Opensearch => "/_search/point_in_time",
+        };
+        Ok(Self::new(Method::DELETE, host.join(path)?, None))
     }
 
     pub fn with_raise_conflict(method: reqwest::Method, url: reqwest::Url, index: String) -> Self {

--- a/assemblyline-server/src/elastic/responses.rs
+++ b/assemblyline-server/src/elastic/responses.rs
@@ -51,13 +51,26 @@ pub struct Multiget<Source, Field> {
 
 #[derive(Deserialize)]
 pub struct OpenPit {
+    #[serde(alias = "pit_id")]
     pub id: String,
 }
 
 #[derive(Deserialize)]
-pub struct ClosePit {
-    pub succeeded: bool,
-    pub num_freed: u32,
+#[serde(untagged)]
+pub enum ClosePit {
+    Elasticsearch {
+        succeeded: bool,
+        num_freed: u32,
+    },
+    Opensearch {
+        pits: Vec<ClosedOpenSearchPit>,
+    },
+}
+
+#[derive(Deserialize)]
+pub struct ClosedOpenSearchPit {
+    pub successful: bool,
+    pub pit_id: String,
 }
 
 /// json response for command queries
@@ -487,4 +500,3 @@ pub struct CreateIndex {
     pub shards_acknowledged: bool,
     pub acknowledged: bool,    
 }
-

--- a/assemblyline-server/src/elastic/search.rs
+++ b/assemblyline-server/src/elastic/search.rs
@@ -13,7 +13,7 @@ use crate::elastic::DEFAULT_SEARCH_FIELD;
 
 use super::pit::PitGuard;
 use super::collection::{Collection, DEFAULT_ROW_SIZE, DEFAULT_SORT};
-use super::{parse_sort, responses, Index, Request, Result};
+use super::{parse_sort, responses, Backend, Index, Request, Result};
 
 
 
@@ -104,7 +104,13 @@ impl<'a, T: Serialize + Readable + Described<ElasticMeta> + Debug> SearchBuilder
         };
 
         let sort = parse_sort(&self.sort)?;
-        let sort = sort.iter().map(|(name, direction)|format!("{name}:{direction}")).collect_vec();
+        let mut sort = sort.iter().map(|(name, direction)|format!("{name}:{direction}")).collect_vec();
+        if matches!(self.target, Target::Pit { .. })
+            && self.collection.database.backend == Backend::Opensearch
+            && !sort.iter().any(|item| item.starts_with("_shard_doc:"))
+        {
+            sort.push("_shard_doc:asc".to_owned());
+        }
 
         let mut params: Vec<(&str, Cow<str>)> = vec![];
         params.push(("size", self.rows.to_string().into()));

--- a/assemblyline-server/src/elastic/test_backend.rs
+++ b/assemblyline-server/src/elastic/test_backend.rs
@@ -1,0 +1,252 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use assemblyline_models::config::DatastoreType;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use super::{convert_wildcards_to_keywords, mapping_for_backend, Backend, ElasticHelper, Request};
+
+async fn mock_root(
+    status: &str,
+    headers: &[(&str, &str)],
+    body: &str,
+) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let server_hits = hits.clone();
+    let status = status.to_owned();
+    let headers = headers
+        .iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect::<Vec<_>>();
+    let body = body.to_owned();
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = [0; 2048];
+        let _ = stream.read(&mut request).await.unwrap();
+        server_hits.fetch_add(1, Ordering::SeqCst);
+        let extra_headers = headers
+            .iter()
+            .map(|(key, value)| format!("{key}: {value}\r\n"))
+            .collect::<String>();
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{extra_headers}Connection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+    });
+    (format!("http://{address}/"), hits)
+}
+
+#[tokio::test]
+async fn explicit_backends_bypass_detection() {
+    let elasticsearch = ElasticHelper::connect_with_backend(
+        "http://127.0.0.1:1",
+        false,
+        None,
+        false,
+        DatastoreType::Elasticsearch,
+    )
+    .await
+    .unwrap();
+    assert_eq!(elasticsearch.backend, Backend::Elasticsearch);
+
+    let opensearch = ElasticHelper::connect_with_backend(
+        "http://127.0.0.1:1",
+        false,
+        None,
+        false,
+        DatastoreType::Opensearch,
+    )
+    .await
+    .unwrap();
+    assert_eq!(opensearch.backend, Backend::Opensearch);
+}
+
+#[tokio::test]
+async fn auto_detects_elasticsearch_once() {
+    let (url, hits) = mock_root(
+        "200 OK",
+        &[("X-Elastic-Product", "Elasticsearch")],
+        r#"{"version":{"number":"8.19.3"},"tagline":"You Know, for Search"}"#,
+    )
+    .await;
+    let helper = ElasticHelper::connect_with_backend(&url, false, None, false, DatastoreType::Auto)
+        .await
+        .unwrap();
+    assert_eq!(helper.backend, Backend::Elasticsearch);
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+    assert_eq!(helper.backend, Backend::Elasticsearch);
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn auto_detects_opensearch_once() {
+    let (url, hits) = mock_root(
+        "200 OK",
+        &[],
+        r#"{"version":{"distribution":"opensearch","number":"2.19.1"},"tagline":"The OpenSearch Project: https://opensearch.org/"}"#,
+    ).await;
+    let helper = ElasticHelper::connect_with_backend(&url, false, None, false, DatastoreType::Auto)
+        .await
+        .unwrap();
+    assert_eq!(helper.backend, Backend::Opensearch);
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn auto_rejects_unsupported_and_malformed_responses() {
+    let (url, _) = mock_root("200 OK", &[], r#"{"version":{"number":"1.2.3"}}"#).await;
+    let error = ElasticHelper::connect_with_backend(&url, false, None, false, DatastoreType::Auto)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("Unsupported or ambiguous"));
+
+    let (url, _) = mock_root(
+        "200 OK",
+        &[("X-Elastic-Product", "Elasticsearch")],
+        r#"{"version":{"distribution":"opensearch"}}"#,
+    )
+    .await;
+    let error = ElasticHelper::connect_with_backend(&url, false, None, false, DatastoreType::Auto)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("Unsupported or ambiguous"));
+
+    let (url, _) = mock_root("200 OK", &[], "not-json").await;
+    let error = ElasticHelper::connect_with_backend(&url, false, None, false, DatastoreType::Auto)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("Malformed"));
+}
+
+#[tokio::test]
+async fn auto_reports_authentication_and_connection_failures() {
+    let (url, _) = mock_root("401 Unauthorized", &[], r#"{"error":"unauthorized"}"#).await;
+    let error = ElasticHelper::connect_with_backend(&url, false, None, false, DatastoreType::Auto)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("authentication failure"));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    drop(listener);
+    let error = ElasticHelper::connect_with_backend(
+        &format!("http://{address}/"),
+        false,
+        None,
+        false,
+        DatastoreType::Auto,
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("connection failure"));
+}
+
+#[test]
+fn backend_specific_pit_requests_are_compatible() {
+    let host = url::Url::parse("http://localhost:9200/").unwrap();
+    let elastic_create = Request::create_pit(&host, "files", "5m", Backend::Elasticsearch).unwrap();
+    let open_create = Request::create_pit(&host, "files", "5m", Backend::Opensearch).unwrap();
+    assert_eq!(elastic_create.url.path(), "/files/_pit");
+    assert_eq!(open_create.url.path(), "/files/_search/point_in_time");
+    assert_eq!(
+        Request::delete_pit(&host, Backend::Elasticsearch)
+            .unwrap()
+            .url
+            .path(),
+        "/_pit"
+    );
+    assert_eq!(
+        Request::delete_pit(&host, Backend::Opensearch)
+            .unwrap()
+            .url
+            .path(),
+        "/_search/point_in_time"
+    );
+    assert_eq!(
+        super::pit::close_body(Backend::Elasticsearch, "elastic-pit".to_owned()),
+        serde_json::json!({"id": "elastic-pit"})
+    );
+    assert_eq!(
+        super::pit::close_body(Backend::Opensearch, "opensearch-pit".to_owned()),
+        serde_json::json!({"pit_id": ["opensearch-pit"]})
+    );
+    let elastic_open: super::responses::OpenPit =
+        serde_json::from_value(serde_json::json!({"id": "elastic-pit"})).unwrap();
+    let open_search_open: super::responses::OpenPit =
+        serde_json::from_value(serde_json::json!({"pit_id": "opensearch-pit"})).unwrap();
+    assert_eq!(elastic_open.id, "elastic-pit");
+    assert_eq!(open_search_open.id, "opensearch-pit");
+    serde_json::from_value::<super::responses::ClosePit>(
+        serde_json::json!({"succeeded": true, "num_freed": 1}),
+    )
+    .unwrap();
+    serde_json::from_value::<super::responses::ClosePit>(
+        serde_json::json!({"pits": [{"successful": true, "pit_id": "opensearch-pit"}]}),
+    )
+    .unwrap();
+}
+
+#[test]
+fn backend_specific_task_requests_are_compatible() {
+    let host = url::Url::parse("http://localhost:9200/").unwrap();
+    assert_eq!(
+        Request::get_task(&host, "node:123", true, "5s")
+            .unwrap()
+            .url
+            .path(),
+        "/_tasks/node:123"
+    );
+    assert!(Backend::Elasticsearch.supports_task_index_cleanup());
+    assert!(!Backend::Opensearch.supports_task_index_cleanup());
+}
+
+#[test]
+fn elasticsearch_security_provisioning_requests_are_unchanged() {
+    let host = url::Url::parse("http://localhost:9200/").unwrap();
+    let role = Request::put_role(&host, "manage_tasks").unwrap();
+    assert_eq!(role.method, reqwest::Method::POST);
+    assert_eq!(role.url.path(), "/_security/role/manage_tasks");
+
+    let user = Request::post_user(&host, "plumber").unwrap();
+    assert_eq!(user.method, reqwest::Method::POST);
+    assert_eq!(user.url.path(), "/_security/user/plumber");
+}
+
+#[test]
+fn wildcard_conversion_is_recursive_and_opensearch_only() {
+    let original = serde_json::json!({
+        "properties": {
+            "top": {"type": "wildcard"},
+            "nested": {"properties": {"child": {"type": "wildcard"}}},
+            "stable": {"type": "keyword"}
+        }
+    });
+    let mut opensearch = original.clone();
+    convert_wildcards_to_keywords(&mut opensearch);
+    assert_eq!(
+        opensearch.pointer("/properties/top/type").unwrap(),
+        "keyword"
+    );
+    assert_eq!(
+        opensearch
+            .pointer("/properties/nested/properties/child/type")
+            .unwrap(),
+        "keyword"
+    );
+    assert_eq!(
+        opensearch.pointer("/properties/stable/type").unwrap(),
+        "keyword"
+    );
+    assert_eq!(
+        original.pointer("/properties/top/type").unwrap(),
+        "wildcard"
+    );
+    assert_eq!(
+        mapping_for_backend(&original, Backend::Elasticsearch).unwrap(),
+        original
+    );
+}

--- a/assemblyline-server/src/main.rs
+++ b/assemblyline-server/src/main.rs
@@ -296,7 +296,14 @@ impl Core {
         let datastore_ca = get_datastore_ca().await?;
         let datastore_ca = datastore_ca.as_ref().map(|val|&val[..]);
         let datastore_verify = get_datastore_verify()?;
-        let datastore = Elastic::connect(&config.datastore.hosts[0], false, datastore_ca, !datastore_verify, elastic_prefix).await?;
+        let datastore = Elastic::connect_with_backend(
+            &config.datastore.hosts[0],
+            false,
+            datastore_ca,
+            !datastore_verify,
+            elastic_prefix,
+            config.datastore.dtype,
+        ).await?;
 
         // connect to filestore
         let filestore = FileStore::open(&config.filestore.storage).await.context("initializing filestore")?;

--- a/assemblyline-server/src/plumber/mod.rs
+++ b/assemblyline-server/src/plumber/mod.rs
@@ -26,7 +26,7 @@ use tokio::task::JoinHandle;
 use crate::constants::{NOTIFICATION_QUEUE_PREFIX, SERVICE_QUEUE_PREFIX, ServiceStage, service_queue_name};
 use crate::dispatcher::client::{DispatchCapable, DispatchClient};
 use crate::elastic::collection::OperationBatch;
-use crate::elastic::Elastic;
+use crate::elastic::{Backend, Elastic};
 use crate::{Core, Flag};
 
 mod http;
@@ -35,6 +35,36 @@ mod tests;
 
 const DAY: TimeDelta = TimeDelta::days(1);
 const TASK_DELETE_CHUNK: u64 = 10000;
+
+enum TaskCleanupStartup {
+    Disabled,
+    Configured {
+        username: String,
+        password: String,
+    },
+    Provision {
+        username: String,
+    },
+}
+
+fn task_cleanup_startup(
+    backend: Backend,
+    enabled: bool,
+    username: Option<String>,
+    password: Option<String>,
+    provision_username: Option<&str>,
+) -> TaskCleanupStartup {
+    if !enabled || !backend.supports_task_index_cleanup() {
+        return TaskCleanupStartup::Disabled;
+    }
+
+    match (username, password) {
+        (Some(username), Some(password)) => TaskCleanupStartup::Configured { username, password },
+        _ => TaskCleanupStartup::Provision {
+            username: provision_username.unwrap_or("plumber").to_owned(),
+        },
+    }
+}
 
 pub async fn main(core: Core) -> Result<()> {
     let mut tasks = tokio::task::JoinSet::new();
@@ -127,19 +157,32 @@ impl<Dispatch: DispatchCapable + Send + Sync> Plumber<Dispatch> {
 
         // Start a task cleanup thread
         let config = self.core.config.core.plumber.clone();
-        if config.enable_task_cleanup {
+        match task_cleanup_startup(
+            self.datastore.backend(),
+            config.enable_task_cleanup,
+            config.task_cleanup_user,
+            config.task_cleanup_password,
+            self.task_user.as_deref(),
+        ) {
+            TaskCleanupStartup::Disabled => {},
+            startup => {
+                let connection = match startup {
+                    TaskCleanupStartup::Configured { username, password } => {
+                        self.core.datastore.switch_to_user(&username, &password).await?
+                    }
+                    TaskCleanupStartup::Provision { username } => {
+                        self.core.datastore.switch_to_new_user(&username).await?
+                    }
+                    TaskCleanupStartup::Disabled => unreachable!(),
+                };
 
-            let connection = match (config.task_cleanup_user, config.task_cleanup_password) {
-                (Some(username), Some(password)) => self.core.datastore.switch_to_user(&username, &password).await?,
-                _ => self.core.datastore.switch_to_new_user(self.task_user.as_deref().unwrap_or("plumber")).await?
-            };
-
-            let this = self.clone();
-            pool.spawn(async move {
-                while let Err(err) = this.cleanup_old_tasks(connection.clone()).await {
-                    error!("Error in datastore task cleanup: {err}");
-                }
-            });
+                let this = self.clone();
+                pool.spawn(async move {
+                    while let Err(err) = this.cleanup_old_tasks(connection.clone()).await {
+                        error!("Error in datastore task cleanup: {err}");
+                    }
+                });
+            }
         }
 
         // Start a notification queue cleanup thread

--- a/assemblyline-server/src/plumber/tests.rs
+++ b/assemblyline-server/src/plumber/tests.rs
@@ -5,10 +5,61 @@ use assemblyline_models::types::ServiceName;
 use reqwest::Method;
 use serde_json::json;
 
+use crate::elastic::Backend;
 use crate::elastic::request::Request;
 use crate::elastic::responses;
+use crate::plumber::{task_cleanup_startup, TaskCleanupStartup};
 use crate::plumber::Plumber;
 use crate::services::test::{dummy_service, setup_services_and_core};
+
+#[test]
+fn elasticsearch_task_cleanup_startup_behavior_is_unchanged() {
+    let configured = task_cleanup_startup(
+        Backend::Elasticsearch,
+        true,
+        Some("cleanup-user".to_owned()),
+        Some("cleanup-password".to_owned()),
+        Some("test-plumber"),
+    );
+    assert!(matches!(
+        configured,
+        TaskCleanupStartup::Configured { username, password }
+            if username == "cleanup-user" && password == "cleanup-password"
+    ));
+
+    let provisioned = task_cleanup_startup(
+        Backend::Elasticsearch,
+        true,
+        Some("incomplete-user".to_owned()),
+        None,
+        Some("test-plumber"),
+    );
+    assert!(matches!(
+        provisioned,
+        TaskCleanupStartup::Provision { username } if username == "test-plumber"
+    ));
+}
+
+#[test]
+fn opensearch_startup_skips_credentials_worker_and_security_plugin() {
+    let configured = task_cleanup_startup(
+        Backend::Opensearch,
+        true,
+        Some("cleanup-user".to_owned()),
+        Some("cleanup-password".to_owned()),
+        Some("test-plumber"),
+    );
+    assert!(matches!(configured, TaskCleanupStartup::Disabled));
+
+    let provisioning = task_cleanup_startup(
+        Backend::Opensearch,
+        true,
+        None,
+        None,
+        Some("test-plumber"),
+    );
+    assert!(matches!(provisioning, TaskCleanupStartup::Disabled));
+}
 
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Adds OpenSearch support to Assemblyline Rust while preserving Elasticsearch as the default backend.

## Changes

- Added `elasticsearch`, `opensearch`, and `auto` datastore types
- Added one-time backend auto-detection during connection setup
- Preserved existing `Elastic::connect` behavior
- Added backend-specific PIT handling
- Added OpenSearch-only mapping compatibility
- Added backend-aware task cleanup behavior
- Skips Elasticsearch-specific cleanup provisioning for OpenSearch
- Added focused backend and plumber tests
- Added an optional OpenSearch Docker Compose profile

## Verification

- `cargo check --workspace` passed
- Backend tests: 9 passed
- Elasticsearch mapping regression: passed
- Plumber startup/provisioning tests: passed
- `git diff --check` passed
